### PR TITLE
docs: slim CLAUDE.md — remove env var duplication and historical build table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,20 +202,7 @@ thinking-foundry/
 ### Deployment
 - Push to main → Railway auto-deploys
 - URL: thinking-foundry-production.up.railway.app
-- Environment variables (Railway — 10 total):
-  - GEMINI_API_KEY — Google AI Studio key for Gemini Live
-  - SUPABASE_URL — Supabase project URL
-  - SUPABASE_KEY — Supabase service role key
-  - GITHUB_TOKEN — Fine-grained PAT for thinking-foundry-vault
-  - GITHUB_OWNER — growthpigs
-  - GITHUB_REPO — thinking-foundry-vault
-  - DEEPGRAM_API_KEY — Deepgram key for user STT
-  - ADMIN_API_KEY — Link auth admin key
-  - GOOGLE_SERVICE_ACCOUNT — Google Drive service account path
-  - NOTEBOOKLM_AUTH_B64 — Base64-encoded NotebookLM auth
-- Environment variables (Vercel — 2):
-  - VITE_WS_URL=wss://thinking-foundry-production.up.railway.app
-  - VITE_API_URL=https://thinking-foundry-production.up.railway.app
+- See **ENVIRONMENT VARIABLES** section above for all 12 vars (Railway + Vercel)
 
 ### What Goes Where
 - Phase prompts → poc/prompts/
@@ -263,20 +250,6 @@ thinking-foundry/
 - ❌ CRUCIBLE_SERVICE_URL (Python service on separate Railway instance)
 - ❌ NOTEBOOKLM_AUTH_B64 (run `notebooklm login`, base64 encode storage_state.json)
 - ❌ UX redesign polish (see [#20](https://github.com/growthpigs/thinking-foundry/issues/20))
-
-### What Was Built (2026-03-30 to 2026-03-31, 36 commits)
-| Component | File | Purpose |
-|---|---|---|
-| SupabaseBuffer | poc/server/supabase-buffer.js | Real-time session persistence (<50ms) |
-| GitHubPersistence | poc/server/github-persistence.js | ONE issue per phase in vault |
-| PhaseTransitionHandler | poc/server/phase-transition.js | AI-driven transitions + active Squeeze |
-| FrameworkFetcher | poc/server/framework-fetcher.js | JIT tool-use via pgvector (78 chunks) |
-| SttPipeline | poc/server/stt-pipeline.js | Deepgram WebSocket for user speech |
-| LinkAuth | poc/server/link-auth.js | Click link, start session, admin page |
-| CrucibleAudio | poc/server/crucible-audio.js | NotebookLM debate audio bridge |
-| DriveManager | poc/server/drive-manager.js | Google Drive folder/doc creation |
-| Session UI | poc/public/session.html | Editorial notebook design, bullet points, phase drawer |
-| React Frontend | frontend/ | Vercel-deployed alternative (to be updated with new design) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Env vars appeared twice: full table on lines 41-55 AND again inside the Deployment section (~204-215). Deployment section now points to the table above.
- Removed 'What Was Built (2026-03-30 to 2026-03-31, 36 commits)' historical table — this is a time-capsule snapshot, not session context. File structure captures where things live.
- 308 → 281 lines (-27 lines, -9%)

## What was NOT touched
- `responseModalities MUST be ['AUDIO']` crash protection rule ✅
- All 8 phase prompts documentation ✅
- Critical Design Principles ✅
- Current Status (what works / what needs work) ✅

## Test plan
- [ ] Verify env var table still complete (Railway 10 + Vercel 2)
- [ ] Verify Gemini Live AUDIO-only rule still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified deployment documentation by consolidating environment variable references into a single section, removing redundant environment-specific breakdowns.
  * Removed outdated component-to-file mapping table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->