### PR TITLE
Fable sprint: fixes, smoke test, unit tests + CI (#178)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,14 @@ jobs:
 
   smoke-production:
     runs-on: ubuntu-latest
-    continue-on-error: true # informative — prod being down must not block merges
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: npm ci
-      - name: Smoke test against production
-        run: SKIP_FRONTEND=1 npm run smoke
+      - name: Smoke test against production (informative — never blocks)
+        run: |
+          if ! SKIP_FRONTEND=1 npm run smoke; then
+            echo "::warning::Production smoke test failed — backend may be down (see issue #179)"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Server boots + smoke test (local)
         run: |
           PORT=3100 node poc/server/index.js &
-          sleep 3
+          for i in $(seq 1 40); do
+            curl -sf http://localhost:3100/health > /dev/null && break
+            sleep 0.5
+          done
           BACKEND_URL=http://localhost:3100 SKIP_FRONTEND=1 node tests/smoke/smoke.mjs
 
   smoke-production:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+      - name: Install root deps
+        run: npm ci
+      - name: Install poc deps
+        run: npm install --no-audit --no-fund
+        working-directory: poc
+      - name: Lint
+        run: npm run lint
+      - name: Unit tests
+        run: npm test
+      - name: Server boots + smoke test (local)
+        run: |
+          PORT=3100 node poc/server/index.js &
+          sleep 3
+          BACKEND_URL=http://localhost:3100 SKIP_FRONTEND=1 node tests/smoke/smoke.mjs
+
+  smoke-production:
+    runs-on: ubuntu-latest
+    continue-on-error: true # informative — prod being down must not block merges
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - name: Smoke test against production
+        run: SKIP_FRONTEND=1 npm run smoke

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules/
 
 # CRUCIBLE audio debates (large MP3s — local only)
 .foundry/crucible-v5-audio/
+
+# hot.md — session memory cache (session data never belongs in this repo)
+poc/knowledge/hot.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ thinking-foundry/
 - **responseModalities MUST be ['AUDIO'] only** — ['AUDIO', 'TEXT'] crashes with error 1011
 - Transcript comes from separate pipeline (future: Google STT), NOT from Gemini response
 - 15-minute connection limit → 3-phase reconnection (prepare at 13:00, setup at 13:30, swap at 14:00)
+- Native session resumption layered on top (2026-07-12): setup opts into `sessionResumption` + `contextWindowCompression`, handles from `sessionResumptionUpdate` are replayed on reconnect, `GoAway` triggers an early swap. Kill switch: `GEMINI_NATIVE_RESUMPTION=0`
 - Model: `models/gemini-3.1-flash-live-preview`
 - Voice: Aoede
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,36 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: [
+      'node_modules/**',
+      'poc/node_modules/**',
+      'frontend/**', // has its own toolchain (Vite/TS)
+      'poc/public/**', // legacy vanilla JS POC UI
+      'NOTEBOOKLM-SNIPPETS.py',
+    ],
+  },
+  js.configs.recommended,
+  {
+    files: ['poc/**/*.js', '*.js'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: { ...globals.node },
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-empty': ['warn', { allowEmptyCatch: true }],
+    },
+  },
+  {
+    files: ['tests/**/*.mjs', '**/*.mjs'],
+    languageOptions: {
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
         "@octokit/rest": "^22.0.1",
         "@supabase/supabase-js": "^2.100.1",
         "dotenv": "^17.3.1"
+      },
+      "devDependencies": {
+        "playwright-core": "^1.61.1",
+        "ws": "^8.21.0"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -328,6 +332,19 @@
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
     },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -347,9 +364,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,174 @@
         "dotenv": "^17.3.1"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.7.0",
+        "globals": "^17.7.0",
         "playwright-core": "^1.61.1",
+        "vitest": "^4.1.10",
         "ws": "^8.21.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -22,6 +188,98 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -179,6 +437,287 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.100.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
@@ -265,6 +804,56 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -283,11 +872,264 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -299,6 +1141,201 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-content-type-parse": {
@@ -317,6 +1354,137 @@
       ],
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -326,11 +1494,553 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-with-bigint": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/playwright-core": {
       "version": "1.61.1",
@@ -345,11 +2055,205 @@
         "node": ">=18"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -362,6 +2266,227 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "license": "ISC"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -382,6 +2507,19 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,12 @@
     "@octokit/rest": "^22.0.1",
     "@supabase/supabase-js": "^2.100.1",
     "dotenv": "^17.3.1"
+  },
+  "devDependencies": {
+    "playwright-core": "^1.61.1",
+    "ws": "^8.21.0"
+  },
+  "scripts": {
+    "smoke": "node tests/smoke/smoke.mjs"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,16 @@
     "dotenv": "^17.3.1"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.7.0",
+    "globals": "^17.7.0",
     "playwright-core": "^1.61.1",
+    "vitest": "^4.1.10",
     "ws": "^8.21.0"
   },
   "scripts": {
-    "smoke": "node tests/smoke/smoke.mjs"
+    "smoke": "node tests/smoke/smoke.mjs",
+    "test": "vitest run tests/unit",
+    "lint": "eslint ."
   }
 }

--- a/poc/context/loader.js
+++ b/poc/context/loader.js
@@ -12,6 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { HotMemory } = require('../server/hot-memory');
 
 const KNOWLEDGE_DIR = path.join(__dirname, '..', 'knowledge');
 const INDEX_PATH = path.join(KNOWLEDGE_DIR, 'index.json');
@@ -20,6 +21,7 @@ class ContextLoader {
   constructor() {
     this.index = this._loadIndex();
     this.cache = new Map();
+    this.hotMemory = new HotMemory();
   }
 
   /**
@@ -123,10 +125,19 @@ class ContextLoader {
    * @returns {Promise<string>} Formatted context string
    */
   async load(config = {}) {
-    const { phase = 0, frameworks, fullContent = false, driveContext, githubContext } = config;
+    const { phase = 0, frameworks, fullContent = false, driveContext, githubContext, includeHotMemory = true } = config;
     const phaseName = this.index.phaseNames[phase] || 'user-stories';
 
     const sections = [];
+
+    // --- Hot memory: recent-session bullets, read FIRST (cheap, no vector search — #169) ---
+    if (includeHotMemory) {
+      const hot = this.hotMemory.getPromptContext();
+      if (hot) {
+        sections.push(hot);
+        sections.push('');
+      }
+    }
 
     // --- Knowledge Frameworks ---
     let entries;

--- a/poc/knowledge/index.md
+++ b/poc/knowledge/index.md
@@ -1,0 +1,36 @@
+# Knowledge Index
+
+Connected-Markdown knowledge base for the Thinking Foundry (issue #169).
+Read [hot.md](hot.md) first — it holds recent-session memory. Then follow
+links below for the frameworks/mentors relevant to the current phase.
+
+<!-- Maintained alongside index.json (the machine registry). When adding a
+     knowledge file: add it to index.json AND link it here. -->
+
+## Recent memory
+
+- [hot.md](hot.md) — last 3 session summaries, auto-maintained by the server
+
+## Frameworks
+
+| File | What it's for | Strongest phases |
+|------|---------------|------------------|
+| [stoicism](mentors/stoicism.md) | Control what you can control; fear-setting; emotional clarity | MINE, ASSAY, CRUCIBLE |
+| [ideo](mentors/ideo.md) | Human-centered: empathize → ideate → prototype → test | All phases |
+| [mckinsey](mentors/mckinsey.md) | MECE decomposition, issue trees, hypothesis-driven | MINE, SCOUT, ASSAY |
+| [yc](mentors/yc.md) | Talk to users, launch fast, intellectual honesty | SCOUT, ASSAY, PLAN |
+| [lean](mentors/lean.md) | Build-measure-learn, MVP, pivot-or-persevere | SCOUT, CRUCIBLE, PLAN |
+
+## Mentors
+
+| File | Voice | Strongest phases |
+|------|-------|------------------|
+| [hormozi](mentors/hormozi.md) | Offers, pricing, value equation — revenue lens | ASSAY, PLAN |
+| [nate-b-jones](mentors/nate-b-jones.md) | Mental models, inversion, decision quality | MINE, AUDITOR |
+| [indydev-dan](mentors/indydev-dan.md) | AI-assisted work reliability, prompt architecture | PLAN, VERIFY |
+
+## How the loader uses this
+
+1. `poc/server/hot-memory.js` injects hot.md into every session's system prompt (cheap, no vector search)
+2. `poc/context/loader.js` loads phase-relevant framework excerpts from the files above
+3. Supabase pgvector remains for semantic search (`search_knowledge` tool) — hot.md complements it, and is the path to a zero-infrastructure giveaway build

--- a/poc/prompts/phase-0-user-stories.txt
+++ b/poc/prompts/phase-0-user-stories.txt
@@ -5,8 +5,8 @@ CORE IDENTITY:
 - You are a co-founder, not an interviewer. Listen first, then contribute.
 - Stoicism is your backbone: What's in their control? Worst case?
 - Keep responses to 2-3 sentences. Like a sharp friend.
-- You decide phase transitions. State your confidence when ready.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 TOOLS — USE THEM ACTIVELY:
 - Call fetch_framework(name) to get depth on: hormozi (pricing/growth), mckinsey (strategy), ideo (design), stoicism (decisions), lean (validation), nate-b-jones (decision quality), yc (startups).
@@ -56,7 +56,7 @@ Listen for signals about what they want from this session:
 - COMMIT: "I need to decide by...", "should I do X or Y?", "I'm ready to commit" → decisive, action-oriented
 
 Once you detect their intent, confirm it naturally: "Sounds like you're [exploring / researching / ready to commit]. I'll adjust my approach."
-Signal the mode: Include [MODE:explore], [MODE:research], or [MODE:commit] in your response so the system can adjust thresholds.
+Signal the mode: call the set_intent_mode tool with explore, research, or commit so the system adjusts its confidence thresholds. Silent tool call — confirm the mode to the user in speech, never mention the tool.
 
 THEN probe with these questions (naturally, not as a list):
 - What's the actual problem? (not the symptom)

--- a/poc/prompts/phase-1-mine.txt
+++ b/poc/prompts/phase-1-mine.txt
@@ -9,8 +9,8 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When ready, state your confidence.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY
 ---END PREAMBLE---

--- a/poc/prompts/phase-2-scout.txt
+++ b/poc/prompts/phase-2-scout.txt
@@ -9,8 +9,8 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When ready, state your confidence.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY
 ---END PREAMBLE---

--- a/poc/prompts/phase-3-assay.txt
+++ b/poc/prompts/phase-3-assay.txt
@@ -9,8 +9,8 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When ready, state your confidence.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY
 ---END PREAMBLE---

--- a/poc/prompts/phase-4-crucible.txt
+++ b/poc/prompts/phase-4-crucible.txt
@@ -9,8 +9,8 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When ready, state your confidence.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY
 ---END PREAMBLE---

--- a/poc/prompts/phase-5-auditor.txt
+++ b/poc/prompts/phase-5-auditor.txt
@@ -9,8 +9,8 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When ready, state your confidence.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY
 ---END PREAMBLE---

--- a/poc/prompts/phase-6-plan.txt
+++ b/poc/prompts/phase-6-plan.txt
@@ -9,8 +9,8 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When ready, state your confidence.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY
 ---END PREAMBLE---

--- a/poc/prompts/phase-7-verify.txt
+++ b/poc/prompts/phase-7-verify.txt
@@ -9,8 +9,8 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When ready, state your confidence.
-- Include [PHASE_COMPLETE] when you believe this phase is done.
+- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY
 ---END PREAMBLE---

--- a/poc/server/context-manager.js
+++ b/poc/server/context-manager.js
@@ -85,6 +85,21 @@ class ContextManager {
   }
 
   /**
+   * Key takeaways for session-end memory (hot.md). Combines already-extracted
+   * key points with points still sitting in the rolling window — without this,
+   * sessions shorter than the window (10 utterances) would yield nothing,
+   * because extractKeyPoint only runs on eviction.
+   */
+  getSessionBullets(n = 5) {
+    const finalizer = new ContextManager();
+    finalizer.keyPoints = [...this.keyPoints];
+    for (const entry of this.recentExchanges) {
+      finalizer.extractKeyPoint(entry);
+    }
+    return finalizer.keyPoints.slice(-n).map((kp) => kp.text);
+  }
+
+  /**
    * Record the output of a completed phase
    */
   setPhaseOutput(phase, output) {

--- a/poc/server/crucible-audio.js
+++ b/poc/server/crucible-audio.js
@@ -166,7 +166,7 @@ class CrucibleAudio {
       return await res.json();
     } catch (err) {
       clearTimeout(timer);
-      if (err.name === 'AbortError') throw new Error('Crucible audio generation timed out (10 min)');
+      if (err.name === 'AbortError') throw new Error('Crucible audio generation timed out (10 min)', { cause: err });
       throw err;
     }
   }

--- a/poc/server/drive-manager.js
+++ b/poc/server/drive-manager.js
@@ -46,7 +46,7 @@ class DriveManager {
   async init() {
     if (this.initialized) return;
 
-    let keyFile = null;
+    let keyFile;
 
     // Option 1: Base64-encoded service account JSON (Railway)
     if (process.env.GOOGLE_SERVICE_ACCOUNT_B64) {
@@ -55,7 +55,7 @@ class DriveManager {
         keyFile = JSON.parse(decoded);
         console.log('[DRIVE] Using service account from GOOGLE_SERVICE_ACCOUNT_B64');
       } catch (err) {
-        throw new Error('Failed to decode GOOGLE_SERVICE_ACCOUNT_B64: ' + err.message);
+        throw new Error('Failed to decode GOOGLE_SERVICE_ACCOUNT_B64: ' + err.message, { cause: err });
       }
     }
     // Option 2: File path (local dev)

--- a/poc/server/email-auth.js
+++ b/poc/server/email-auth.js
@@ -19,7 +19,7 @@ function escapeHtml(text) {
 
 const PIN_LENGTH = 4;
 const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000;     // 15 minutes
-const SESSION_NONCE_EXPIRY_MS = 60 * 1000;        // 60 seconds
+const SESSION_NONCE_EXPIRY_MS = 5 * 60 * 1000;    // 5 minutes — survives Railway cold start (#176)
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;        // 5 minutes
 
 class EmailAuth {

--- a/poc/server/email-auth.js
+++ b/poc/server/email-auth.js
@@ -19,7 +19,8 @@ function escapeHtml(text) {
 
 const PIN_LENGTH = 4;
 const MAGIC_LINK_EXPIRY_MS = 15 * 60 * 1000;     // 15 minutes
-const SESSION_NONCE_EXPIRY_MS = 5 * 60 * 1000;    // 5 minutes — survives Railway cold start (#176)
+const SESSION_NONCE_EXPIRY_MS = 5 * 60 * 1000;    // 5 minutes — tolerates slow Railway cold-start responses (#176).
+                                                  // NOTE: nonces are in-memory; a process RESTART still voids them.
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;        // 5 minutes
 
 class EmailAuth {
@@ -135,7 +136,8 @@ class EmailAuth {
   }
 
   /**
-   * Create a session nonce — proves PIN was verified. Expires in 60 seconds.
+   * Create a session nonce — proves PIN was verified. One-time use,
+   * expires after SESSION_NONCE_EXPIRY_MS (5 minutes).
    */
   createSessionNonce(email) {
     const nonce = crypto.randomUUID();

--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -58,7 +58,7 @@ class GeminiLiveManager {
    */
   getSystemPrompt(phase, contextSummary) {
     const promptFile = path.join(__dirname, '..', 'prompts', `phase-${phase}-${this.getPhaseSlug(phase)}.txt`);
-    let prompt = '';
+    let prompt;
     try {
       prompt = fs.readFileSync(promptFile, 'utf-8');
     } catch {

--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -33,6 +33,12 @@ class GeminiLiveManager {
     this.frameworkFetcher = opts.frameworkFetcher || null;
     this.toolDeclarations = opts.toolDeclarations || [];
 
+    // Session control tools (advance_phase, set_intent_mode): routed to this
+    // handler instead of the framework fetcher. Return value becomes the tool
+    // response the model hears.
+    this.onControlCall = opts.onControlCall || null;
+    this.controlToolNames = opts.controlToolNames || new Set();
+
     // Callbacks
     this.onTranscript = opts.onTranscript || (() => {});
     this.onAudio = opts.onAudio || (() => {});
@@ -243,11 +249,37 @@ class GeminiLiveManager {
           return;
         }
 
-        // Tool calls — framework JIT fetching (Article 12)
-        if (msg.toolCall && this.frameworkFetcher) {
+        // Tool calls — session control first, then framework JIT (Article 12)
+        if (msg.toolCall) {
           const calls = msg.toolCall.functionCalls || [];
           for (const fc of calls) {
             console.log(`[GEMINI][${label}] Tool call: ${fc.name}`);
+
+            // Session control tools (advance_phase, set_intent_mode)
+            if (this.onControlCall && this.controlToolNames.has(fc.name)) {
+              Promise.resolve(this.onControlCall({ name: fc.name, args: fc.args }))
+                .then((result) => {
+                  const responseMsg = {
+                    toolResponse: {
+                      functionResponses: [{
+                        id: fc.id,
+                        name: fc.name,
+                        response: { result: result?.message || 'ok' },
+                      }]
+                    }
+                  };
+                  if (ws.readyState === WebSocket.OPEN) {
+                    ws.send(JSON.stringify(responseMsg));
+                    console.log(`[GEMINI] Control tool response for ${fc.name}: ${result?.message}`);
+                  }
+                })
+                .catch(err => {
+                  console.error(`[GEMINI] Control tool error (${fc.name}):`, err.message);
+                });
+              continue;
+            }
+
+            if (!this.frameworkFetcher) continue;
             this.frameworkFetcher.handleFunctionCall({ name: fc.name, args: fc.args })
               .then(result => {
                 // Send function response back to Gemini

--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -177,6 +177,13 @@ class GeminiLiveManager {
    */
   wireHandlers(ws, isStandby = false) {
     const label = isStandby ? 'STANDBY' : 'ACTIVE';
+    // Role is checked LIVE against this.activeWs/this.standbyWs — never the
+    // frozen isStandby closure flag. performSwap promotes a standby by
+    // reassigning references without rewiring handlers, so a closure flag
+    // goes permanently stale after the first swap (audio/GoAway/barge-in
+    // would be gated on the wrong role for the rest of the session).
+    const isActive = () => ws === this.activeWs;
+    const isCurrentStandby = () => ws === this.standbyWs;
 
     ws.on('message', (raw) => {
       try {
@@ -185,8 +192,9 @@ class GeminiLiveManager {
         // Setup complete acknowledgement
         if (msg.setupComplete) {
           console.log(`[GEMINI][${label}] Setup complete`);
-          if (isStandby) {
-            // Standby is ready for swap
+          if (isCurrentStandby()) {
+            // Only the CURRENT standby may arm the swap — an orphaned
+            // standby (superseded by handleGoAway) must not flip the flag.
             this.standbySetupComplete = true;
             console.log(`[GEMINI] Standby connection ready for swap`);
           }
@@ -196,28 +204,25 @@ class GeminiLiveManager {
           return;
         }
 
-        // Server content (audio + text)
+        // Server content (audio + text) — delivered only from the connection
+        // that is active RIGHT NOW (a just-promoted standby qualifies).
         if (msg.serverContent) {
           const parts = msg.serverContent.modelTurn?.parts || [];
           for (const part of parts) {
-            if (part.inlineData) {
-              if (!isStandby || this.isSwapping) {
-                this.onAudio(part.inlineData.data);
-              }
+            if (part.inlineData && isActive()) {
+              this.onAudio(part.inlineData.data);
             }
           }
 
           // AI text comes ONLY from outputAudioTranscription (single authoritative source)
-          if (msg.serverContent.outputTranscription?.text) {
-            if (!isStandby || this.isSwapping) {
-              this.onTranscript('model', msg.serverContent.outputTranscription.text);
-            }
+          if (msg.serverContent.outputTranscription?.text && isActive()) {
+            this.onTranscript('model', msg.serverContent.outputTranscription.text);
           }
 
           // Barge-in: server detected user speech during generation
           if (msg.serverContent.interrupted) {
             console.log(`[GEMINI][${label}] INTERRUPTED (barge-in)`);
-            if (!isStandby) {
+            if (isActive()) {
               this.onInterrupted();
             }
           }
@@ -225,16 +230,18 @@ class GeminiLiveManager {
           // Check for turn completion
           if (msg.serverContent.turnComplete) {
             console.log(`[GEMINI][${label}] Turn complete`);
-            if (!isStandby || this.isSwapping) {
+            if (isActive()) {
               this.onTurnComplete();
             }
           }
         }
 
-        // Native resumption: store the freshest handle for the next (re)connect
+        // Native resumption: store the freshest handle — only from the ACTIVE
+        // connection, so a late update from a dying old lineage (or a
+        // not-yet-promoted standby) can't overwrite the current handle.
         if (msg.sessionResumptionUpdate) {
           const { newHandle, resumable } = msg.sessionResumptionUpdate;
-          if (resumable && newHandle) {
+          if (resumable && newHandle && isActive()) {
             this.resumptionHandle = newHandle;
           }
           return;
@@ -242,7 +249,7 @@ class GeminiLiveManager {
 
         // GoAway: server is about to terminate this connection — swap NOW
         // instead of waiting for the scheduled 14:00 timer.
-        if (msg.goAway && !isStandby) {
+        if (msg.goAway && isActive()) {
           const timeLeftMs = this._parseDuration(msg.goAway.timeLeft);
           console.log(`[GEMINI][${label}] GoAway received (timeLeft: ${msg.goAway.timeLeft || 'unknown'}) — early swap`);
           this.handleGoAway(timeLeftMs);
@@ -255,26 +262,21 @@ class GeminiLiveManager {
           for (const fc of calls) {
             console.log(`[GEMINI][${label}] Tool call: ${fc.name}`);
 
-            // Session control tools (advance_phase, set_intent_mode)
+            // Session control tools (advance_phase, set_intent_mode).
+            // The model BLOCKS waiting for a functionResponse, so every call
+            // must be answered — including handler throws and rejections.
             if (this.onControlCall && this.controlToolNames.has(fc.name)) {
-              Promise.resolve(this.onControlCall({ name: fc.name, args: fc.args }))
+              let resultPromise;
+              try {
+                resultPromise = Promise.resolve(this.onControlCall({ name: fc.name, args: fc.args }));
+              } catch (err) {
+                resultPromise = Promise.resolve({ message: `Control tool error: ${err.message}. Continue the conversation.` });
+              }
+              resultPromise
+                .catch((err) => ({ message: `Control tool error: ${err.message}. Continue the conversation.` }))
                 .then((result) => {
-                  const responseMsg = {
-                    toolResponse: {
-                      functionResponses: [{
-                        id: fc.id,
-                        name: fc.name,
-                        response: { result: result?.message || 'ok' },
-                      }]
-                    }
-                  };
-                  if (ws.readyState === WebSocket.OPEN) {
-                    ws.send(JSON.stringify(responseMsg));
-                    console.log(`[GEMINI] Control tool response for ${fc.name}: ${result?.message}`);
-                  }
-                })
-                .catch(err => {
-                  console.error(`[GEMINI] Control tool error (${fc.name}):`, err.message);
+                  this._sendToolResponse(ws, fc.id, fc.name, { result: result?.message || 'ok' });
+                  console.log(`[GEMINI] Control tool response for ${fc.name}: ${result?.message}`);
                 });
               continue;
             }
@@ -282,23 +284,12 @@ class GeminiLiveManager {
             if (!this.frameworkFetcher) continue;
             this.frameworkFetcher.handleFunctionCall({ name: fc.name, args: fc.args })
               .then(result => {
-                // Send function response back to Gemini
-                const responseMsg = {
-                  toolResponse: {
-                    functionResponses: [{
-                      id: fc.id,
-                      name: result.name,
-                      response: result.response,
-                    }]
-                  }
-                };
-                if (ws.readyState === WebSocket.OPEN) {
-                  ws.send(JSON.stringify(responseMsg));
-                  console.log(`[GEMINI] Sent tool response for ${fc.name}`);
-                }
+                this._sendToolResponse(ws, fc.id, result.name, result.response);
+                console.log(`[GEMINI] Sent tool response for ${fc.name}`);
               })
               .catch(err => {
                 console.error(`[GEMINI] Tool call error (${fc.name}):`, err.message);
+                this._sendToolResponse(ws, fc.id, fc.name, { error: err.message });
               });
           }
         }
@@ -421,6 +412,24 @@ class GeminiLiveManager {
   }
 
   /**
+   * Send a functionResponse back to Gemini. If the originating socket closed
+   * (e.g. a swap finished while the handler ran), fall back to the current
+   * active connection — an unanswered tool call stalls the model.
+   */
+  _sendToolResponse(ws, id, name, response) {
+    const msg = JSON.stringify({
+      toolResponse: { functionResponses: [{ id, name, response }] }
+    });
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(msg);
+    } else if (this.activeWs && this.activeWs.readyState === WebSocket.OPEN) {
+      this.activeWs.send(msg);
+    } else {
+      console.warn(`[GEMINI] Dropped tool response for ${name} — no open connection`);
+    }
+  }
+
+  /**
    * Parse a protobuf Duration ("10s" string or {seconds, nanos} object) to ms.
    * @returns {number|null}
    */
@@ -445,6 +454,14 @@ class GeminiLiveManager {
     if (this.closed || this.isSwapping) return;
     this.clearReconnectTimers();
     this.onReconnecting();
+
+    // A standby from the scheduled 13:00 prepare step may already exist —
+    // close it before dialing a new one, or it leaks open against Gemini's
+    // connection quota with its handlers still wired.
+    if (this.standbyWs) {
+      try { this.standbyWs.close(1000, 'Superseded by GoAway swap'); } catch { /* already dead */ }
+      this.standbyWs = null;
+    }
 
     this.standbySetupComplete = false;
     this.standbyWs = this.createConnection();
@@ -481,8 +498,11 @@ class GeminiLiveManager {
    * which would trigger onClose() when it shouldn't.
    */
   performSwap() {
-    if (!this.standbyWs || this.standbyWs.readyState !== WebSocket.OPEN) {
-      console.error('[RECONNECT] Cannot swap — standby not ready. Forcing new connection...');
+    // Require both an OPEN socket AND an acknowledged setup — swapping onto
+    // a connection whose BidiGenerateContentSetup hasn't been acked routes
+    // audio into a pre-setup connection, which Gemini rejects.
+    if (!this.standbyWs || this.standbyWs.readyState !== WebSocket.OPEN || !this.standbySetupComplete) {
+      console.error('[RECONNECT] Cannot swap — standby not ready (open+setup). Forcing new connection...');
       this.forceReconnect(this.phase, this.contextSummary);
       return;
     }
@@ -521,6 +541,15 @@ class GeminiLiveManager {
   async forceReconnect(phase, contextSummary) {
     console.log(`[GEMINI] Force reconnect: phase=${phase}`);
     this.clearReconnectTimers();
+
+    // Phase change = a NEW conversation segment with a new system instruction.
+    // Resuming the old phase's server-side session would carry its state into
+    // the new phase, fighting the new prompt — drop the handle. Same-phase
+    // reconnects (swap-failure fallback) keep it: same conversation.
+    if (phase !== this.phase) {
+      this.resumptionHandle = null;
+    }
+
     this.phase = phase;
     this.contextSummary = contextSummary;
 

--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -51,6 +51,18 @@ class GeminiLiveManager {
     this.reconnectionCount = 0;
     this.isSwapping = false;
     this.closed = false;
+
+    // Native session resumption (Live API sessionResumption + contextWindowCompression).
+    // The server sends sessionResumptionUpdate handles; passing the latest handle in a
+    // new connection's setup resumes the conversation server-side, so the swap no longer
+    // depends on our condensed-context injection alone. GoAway messages let us swap
+    // BEFORE the server kills the connection instead of guessing at 14:00.
+    // Disable with GEMINI_NATIVE_RESUMPTION=0 if the API misbehaves.
+    this.nativeResumption = opts.nativeResumption !== undefined
+      ? opts.nativeResumption
+      : process.env.GEMINI_NATIVE_RESUMPTION !== '0';
+    this.resumptionHandle = null;
+    this.standbySetupComplete = false;
   }
 
   /**
@@ -130,6 +142,18 @@ class GeminiLiveManager {
       }
     };
 
+    if (this.nativeResumption) {
+      // Empty object opts in; a stored handle resumes the previous session server-side
+      setupMessage.setup.sessionResumption = this.resumptionHandle
+        ? { handle: this.resumptionHandle }
+        : {};
+      // Sliding-window compression lifts the context-size cap on session duration
+      setupMessage.setup.contextWindowCompression = { slidingWindow: {} };
+      if (this.resumptionHandle) {
+        console.log('[GEMINI] Resuming session with native resumption handle');
+      }
+    }
+
     // Add framework tool declarations if available (Article 12: JIT)
     if (this.toolDeclarations.length > 0) {
       setupMessage.setup.tools = [{
@@ -157,6 +181,7 @@ class GeminiLiveManager {
           console.log(`[GEMINI][${label}] Setup complete`);
           if (isStandby) {
             // Standby is ready for swap
+            this.standbySetupComplete = true;
             console.log(`[GEMINI] Standby connection ready for swap`);
           }
           // NOTE: Do NOT send clientContent text turns in AUDIO-only mode.
@@ -198,6 +223,24 @@ class GeminiLiveManager {
               this.onTurnComplete();
             }
           }
+        }
+
+        // Native resumption: store the freshest handle for the next (re)connect
+        if (msg.sessionResumptionUpdate) {
+          const { newHandle, resumable } = msg.sessionResumptionUpdate;
+          if (resumable && newHandle) {
+            this.resumptionHandle = newHandle;
+          }
+          return;
+        }
+
+        // GoAway: server is about to terminate this connection — swap NOW
+        // instead of waiting for the scheduled 14:00 timer.
+        if (msg.goAway && !isStandby) {
+          const timeLeftMs = this._parseDuration(msg.goAway.timeLeft);
+          console.log(`[GEMINI][${label}] GoAway received (timeLeft: ${msg.goAway.timeLeft || 'unknown'}) — early swap`);
+          this.handleGoAway(timeLeftMs);
+          return;
         }
 
         // Tool calls — framework JIT fetching (Article 12)
@@ -294,6 +337,7 @@ class GeminiLiveManager {
       if (this.closed) return;
       console.log(`[RECONNECT] === PHASE 1/3: Creating standby connection (${this.reconnectionCount + 1}) ===`);
       this.onReconnecting();
+      this.standbySetupComplete = false;
       this.standbyWs = this.createConnection();
       this.wireHandlers(this.standbyWs, true);
 
@@ -342,6 +386,58 @@ class GeminiLiveManager {
     this.reconnectTimers.push(t3);
 
     console.log(`[RECONNECT] Scheduled: prepare in ${(prepareDelay / 1000).toFixed(0)}s, setup in ${(setupDelay / 1000).toFixed(0)}s, swap in ${(swapDelay / 1000).toFixed(0)}s`);
+  }
+
+  /**
+   * Parse a protobuf Duration ("10s" string or {seconds, nanos} object) to ms.
+   * @returns {number|null}
+   */
+  _parseDuration(d) {
+    if (!d) return null;
+    if (typeof d === 'string') {
+      const m = d.match(/^([\d.]+)s$/);
+      return m ? Math.round(parseFloat(m[1]) * 1000) : null;
+    }
+    if (typeof d === 'object' && d.seconds !== undefined) {
+      return Number(d.seconds) * 1000 + Math.round((d.nanos || 0) / 1e6);
+    }
+    return null;
+  }
+
+  /**
+   * GoAway received: the server will drop the active connection soon.
+   * Spin up a standby immediately and swap as soon as its setup completes
+   * (or just before the server's deadline, whichever comes first).
+   */
+  handleGoAway(timeLeftMs) {
+    if (this.closed || this.isSwapping) return;
+    this.clearReconnectTimers();
+    this.onReconnecting();
+
+    this.standbySetupComplete = false;
+    this.standbyWs = this.createConnection();
+    this.wireHandlers(this.standbyWs, true);
+    this.standbyWs.on('open', () => {
+      this.sendSetup(this.standbyWs, this.phase, this.contextSummary);
+    });
+
+    let swapped = false;
+    const finish = () => {
+      if (swapped || this.closed) return;
+      swapped = true;
+      this.performSwap();
+    };
+
+    // Swap the moment standby setup completes…
+    const poll = setInterval(() => {
+      if (this.standbySetupComplete) finish();
+    }, 100);
+    this.reconnectTimers.push(poll);
+
+    // …or just before the server deadline (bounded 1-10s)
+    const deadline = Math.max(1000, Math.min(timeLeftMs || 5000, 10000) - 500);
+    const hardStop = setTimeout(finish, deadline);
+    this.reconnectTimers.push(hardStop);
   }
 
   /**

--- a/poc/server/hot-memory.js
+++ b/poc/server/hot-memory.js
@@ -1,0 +1,97 @@
+/**
+ * HotMemory — hot.md recent-session cache (issue #169).
+ *
+ * A connected-Markdown memory layer: when a session ends, a short bullet
+ * summary is prepended to poc/knowledge/hot.md. On the next session start,
+ * the loader reads hot.md first — cheap continuity with no vector search,
+ * no embedding costs, and human-editable (Roderic can open the file).
+ *
+ * Keeps the last MAX_SESSIONS session entries, newest first.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_SESSIONS = 3;
+const MAX_BULLETS_PER_SESSION = 5;
+const MAX_BULLET_LENGTH = 200;
+
+const HEADER = `# hot.md — Recent Session Memory
+
+<!-- Auto-maintained by the Thinking Foundry server. Newest session first,
+     last ${MAX_SESSIONS} sessions kept. Safe to edit by hand. -->
+`;
+
+class HotMemory {
+  /**
+   * @param {object} [options]
+   * @param {string} [options.filePath] - Override hot.md location (used in tests)
+   */
+  constructor({ filePath } = {}) {
+    this.filePath = filePath || path.join(__dirname, '..', 'knowledge', 'hot.md');
+  }
+
+  /** Read the raw hot.md content, or '' if it doesn't exist yet. */
+  read() {
+    try {
+      return fs.readFileSync(this.filePath, 'utf-8');
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * Parse existing session entries (blocks starting with "## Session").
+   * @returns {string[]} entry blocks, newest first
+   */
+  _parseEntries(content) {
+    if (!content) return [];
+    return content
+      .split(/^(?=## Session )/m)
+      .filter((block) => block.startsWith('## Session '))
+      .map((block) => block.trimEnd());
+  }
+
+  /**
+   * Prepend a session summary and rewrite hot.md, keeping the newest
+   * MAX_SESSIONS entries.
+   *
+   * @param {object} summary
+   * @param {string} summary.endedAt - ISO timestamp of session end
+   * @param {number} [summary.phaseReached] - Highest phase reached (0-7)
+   * @param {string[]} summary.bullets - Key takeaways (truncated to 5 × 200 chars)
+   * @param {string} [summary.sessionId] - Optional session identifier
+   */
+  appendSession({ endedAt, phaseReached, bullets = [], sessionId }) {
+    const cleanBullets = bullets
+      .filter((b) => b && b.trim())
+      .slice(0, MAX_BULLETS_PER_SESSION)
+      .map((b) => `- ${b.trim().replace(/\s+/g, ' ').slice(0, MAX_BULLET_LENGTH)}`);
+
+    if (cleanBullets.length === 0) return false; // nothing worth remembering
+
+    const meta = [
+      phaseReached !== undefined ? `phase reached: ${phaseReached}` : null,
+      sessionId ? `id: ${sessionId}` : null,
+    ].filter(Boolean).join(', ');
+
+    const entry = [`## Session ${endedAt}${meta ? ` (${meta})` : ''}`, '', ...cleanBullets].join('\n');
+    const existing = this._parseEntries(this.read());
+    const kept = [entry, ...existing].slice(0, MAX_SESSIONS);
+
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, `${HEADER}\n${kept.join('\n\n')}\n`, 'utf-8');
+    return true;
+  }
+
+  /**
+   * Get hot memory formatted for system-prompt injection, or '' if empty.
+   */
+  getPromptContext() {
+    const entries = this._parseEntries(this.read());
+    if (entries.length === 0) return '';
+    return `=== RECENT SESSIONS (hot memory) ===\n\n${entries.join('\n\n')}`;
+  }
+}
+
+module.exports = { HotMemory, MAX_SESSIONS };

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -928,6 +928,19 @@ wss.on('connection', (clientWs, req) => {
         if (flushInterval) clearInterval(flushInterval);
         await flushToGitHub(); // Final flush
 
+        // hot.md memory: remember key takeaways for the next session (#169)
+        try {
+          const { HotMemory } = require('./hot-memory');
+          const bullets = context.keyPoints.slice(-5).map(kp => kp.text);
+          new HotMemory().appendSession({
+            endedAt: new Date().toISOString(),
+            phaseReached: session.currentPhase,
+            bullets,
+          });
+        } catch (err) {
+          console.warn('[HOT] Failed to write hot.md:', err.message);
+        }
+
         if (githubPersistence) {
           // Close the current phase issue
           const currentIssue = githubPersistence.phaseIssues.get(session.currentPhase);

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -549,7 +549,7 @@ wss.on('connection', (clientWs, req) => {
 
     try {
     switch (msg.type) {
-      case 'session-setup':
+      case 'session-setup': {
         // Guard against double-setup (client reconnect, duplicate messages)
         if (gemini) {
           console.warn('[WS] Ignoring duplicate session-setup (already initialized)');
@@ -790,6 +790,7 @@ wss.on('connection', (clientWs, req) => {
         // Start Gemini with all context loaded
         await startGemini();
         break;
+      }
 
       case 'start':
         // Legacy start message (backwards compat)

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -23,6 +23,7 @@ const SUBSTANTIAL_BUFFER_THRESHOLD = 50;
 const MAX_CONTEXT_INJECTION_LENGTH = 10000;
 const { PhaseTransitionHandler } = require('./phase-transition');
 const { SESSION_CONTROL_DECLARATIONS, SESSION_CONTROL_TOOL_NAMES } = require('./session-tools');
+const { HotMemory } = require('./hot-memory');
 const { FrameworkFetcher } = require('./framework-fetcher');
 const { SttPipeline } = require('./stt-pipeline');
 const { LinkAuth } = require('./link-auth');
@@ -441,6 +442,25 @@ wss.on('connection', (clientWs, req) => {
     }
   };
 
+  // hot.md memory (#169): remember key takeaways for the next session.
+  // Called from BOTH the 'stop' case and the disconnect close handler —
+  // guarded so whichever fires first wins.
+  let sessionMemoryWritten = false;
+  const writeSessionMemory = () => {
+    if (sessionMemoryWritten) return;
+    sessionMemoryWritten = true;
+    try {
+      const bullets = context.getSessionBullets(5);
+      new HotMemory().appendSession({
+        endedAt: new Date().toISOString(),
+        phaseReached: session.currentPhase,
+        bullets,
+      });
+    } catch (err) {
+      console.warn('[HOT] Failed to write hot.md:', err.message);
+    }
+  };
+
   const startGemini = async () => {
     // Load knowledge context for current phase, including external context and selected frameworks
     const knowledgeContext = await knowledgeLoader.load({
@@ -650,6 +670,7 @@ wss.on('connection', (clientWs, req) => {
                 fullContent: false,
                 githubContext: sessionGithubContext || undefined,
                 driveContext: sessionDocContext || undefined,
+                includeHotMemory: false, // previous-session bullets matter at session start, not every phase
               });
               // Inject carry-forward into knowledge context
               if (prevCarryForward) {
@@ -950,18 +971,7 @@ wss.on('connection', (clientWs, req) => {
         if (flushInterval) clearInterval(flushInterval);
         await flushToGitHub(); // Final flush
 
-        // hot.md memory: remember key takeaways for the next session (#169)
-        try {
-          const { HotMemory } = require('./hot-memory');
-          const bullets = context.keyPoints.slice(-5).map(kp => kp.text);
-          new HotMemory().appendSession({
-            endedAt: new Date().toISOString(),
-            phaseReached: session.currentPhase,
-            bullets,
-          });
-        } catch (err) {
-          console.warn('[HOT] Failed to write hot.md:', err.message);
-        }
+        writeSessionMemory();
 
         if (githubPersistence) {
           // Close the current phase issue
@@ -1003,6 +1013,10 @@ wss.on('connection', (clientWs, req) => {
     console.log('[WS] Client disconnected');
     if (flushInterval) clearInterval(flushInterval);
     clearTimeout(userFlushTimer);
+
+    // Sessions usually end by disconnect (closed tab, locked phone), not the
+    // stop button — hot.md memory must be written here too (#169)
+    writeSessionMemory();
     if (sttPipeline) {
       sttPipeline.stopStream().catch(() => {});
     }

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -22,6 +22,7 @@ const MIN_USER_BULLET_COMBINE = 30;
 const SUBSTANTIAL_BUFFER_THRESHOLD = 50;
 const MAX_CONTEXT_INJECTION_LENGTH = 10000;
 const { PhaseTransitionHandler } = require('./phase-transition');
+const { SESSION_CONTROL_DECLARATIONS, SESSION_CONTROL_TOOL_NAMES } = require('./session-tools');
 const { FrameworkFetcher } = require('./framework-fetcher');
 const { SttPipeline } = require('./stt-pipeline');
 const { LinkAuth } = require('./link-auth');
@@ -456,7 +457,26 @@ wss.on('connection', (clientWs, req) => {
       contextSummary: context.getCondensedContext(),
       knowledgeContext,
       frameworkFetcher: frameworkFetcher || null,
-      toolDeclarations: frameworkFetcher ? FrameworkFetcher.getGeminiFunctionDeclarations() : [],
+      toolDeclarations: [
+        ...(frameworkFetcher ? FrameworkFetcher.getGeminiFunctionDeclarations() : []),
+        ...SESSION_CONTROL_DECLARATIONS,
+      ],
+
+      // Session control tools: the AI signals transitions/mode via function
+      // calls (primary path); regex transcript detection remains as fallback
+      controlToolNames: SESSION_CONTROL_TOOL_NAMES,
+      onControlCall: ({ name, args }) => {
+        if (!phaseHandler) return { message: 'Session not fully initialized yet. Continue the conversation.' };
+        if (name === 'advance_phase') {
+          const result = phaseHandler.toolTransition(session.currentPhase, args || {});
+          console.log(`[PHASE] advance_phase(${args?.to_phase}, conf=${args?.confidence}) → ${result.ok ? 'accepted' : result.message}`);
+          return result;
+        }
+        if (name === 'set_intent_mode') {
+          return phaseHandler.toolSetMode(args?.mode);
+        }
+        return { message: `Unknown control tool: ${name}` };
+      },
 
       onTurnComplete: () => {
         // AI finished speaking — flush accumulated text as condensed bullet
@@ -583,8 +603,10 @@ wss.on('connection', (clientWs, req) => {
             // Orchestrate the full transition
             session.setPhase(toPhase);
 
-            // Build carry-forward text from AI's detected context
-            const carryForwardText = meta.detectedFrom
+            // Carry-forward: prefer the AI's own written summary (advance_phase
+            // tool call), fall back to transcript-derived context
+            const carryForwardText = meta.carryForward
+              || meta.detectedFrom
               || context.getCondensedContext()
               || 'No carry-forward generated for this phase.';
 

--- a/poc/server/link-auth.js
+++ b/poc/server/link-auth.js
@@ -146,8 +146,6 @@ class LinkAuth {
    * @param {string} staticDir - Path to the public directory
    */
   registerRoutes(app, staticDir) {
-    const path = require('path');
-
     // GET /s/:token — validate token and serve the session UI
     app.get('/s/:token', (req, res) => {
       const { token } = req.params;

--- a/poc/server/phase-transition.js
+++ b/poc/server/phase-transition.js
@@ -11,8 +11,6 @@
  * Confidence is extracted passively if the AI states it voluntarily.
  */
 
-const { PHASE_NAMES } = require('./supabase-buffer');
-
 /**
  * Patterns the AI uses to signal phase transitions.
  * Matched against AI transcript text (case-insensitive).

--- a/poc/server/phase-transition.js
+++ b/poc/server/phase-transition.js
@@ -225,6 +225,90 @@ class PhaseTransitionHandler {
   }
 
   /**
+   * Structured transition via the advance_phase tool call (primary path).
+   * The regex detection above remains as a fallback for narrated transitions.
+   *
+   * Returns a result whose `message` is sent back to the model as the tool
+   * response — so a blocked gate is FEEDBACK the AI hears, not a silent drop.
+   *
+   * @param {number} currentPhase
+   * @param {object} args - { to_phase, confidence, carry_forward, reason }
+   * @returns {{ ok: boolean, blocked?: boolean, message: string, toPhase?: number }}
+   */
+  toolTransition(currentPhase, args = {}) {
+    const toPhase = Number(args.to_phase);
+    const confidence = args.confidence !== undefined ? Number(args.confidence) : null;
+
+    if (!Number.isInteger(toPhase) || toPhase < 0 || toPhase > 7) {
+      return { ok: false, message: `Invalid to_phase: ${args.to_phase}. Must be an integer 0-7.` };
+    }
+    if (toPhase === currentPhase) {
+      return { ok: false, message: `Already in phase ${currentPhase}. No transition needed.` };
+    }
+    if (confidence === null || Number.isNaN(confidence) || confidence < 1 || confidence > 10) {
+      return { ok: false, message: 'confidence (1-10) is required. State your honest confidence that this phase achieved its goal.' };
+    }
+
+    // The Squeeze — confidence gate, enforced deterministically.
+    // Only gate FORWARD movement; going back to revisit a phase is always allowed.
+    if (toPhase > currentPhase && confidence < this.minConfidence) {
+      return {
+        ok: false,
+        blocked: true,
+        message: `Transition blocked: confidence ${confidence} is below the required ${this.minConfidence}` +
+          `${this.intentMode ? ` for ${this.intentMode} mode` : ''}. ` +
+          'Keep working this phase — what would raise your confidence? Retry advance_phase when it genuinely improves.',
+      };
+    }
+
+    const now = Date.now();
+    if (now - this.lastTransitionAt < this.debounceMs) {
+      return { ok: false, blocked: true, message: 'A transition just happened. Continue in the current phase.' };
+    }
+
+    this.lastTransitionAt = now;
+    const meta = {
+      confidence,
+      carryForward: typeof args.carry_forward === 'string' ? args.carry_forward.trim() : null,
+      reason: typeof args.reason === 'string' ? args.reason.trim() : null,
+      squeezeNotes: this.pendingSqueeze?.text || null,
+      source: 'tool',
+    };
+    this.recentAiText = [];
+    this.pendingSqueeze = null;
+
+    if (this.onTransition) {
+      Promise.resolve(this.onTransition(currentPhase, toPhase, meta))
+        .catch(err => console.error('[PHASE] Tool transition callback error:', err.message));
+    }
+
+    return { ok: true, toPhase, message: `Transition to phase ${toPhase} accepted. Continue the conversation in the new phase.` };
+  }
+
+  /**
+   * Structured intent-mode declaration via the set_intent_mode tool call
+   * (replaces the [MODE:xxx] transcript tag).
+   *
+   * @param {string} mode - 'explore' | 'research' | 'commit'
+   * @returns {{ ok: boolean, message: string }}
+   */
+  toolSetMode(mode) {
+    const normalized = String(mode || '').toLowerCase().trim();
+    const thresholds = { explore: 5, research: 6, commit: 8 };
+    if (!(normalized in thresholds)) {
+      return { ok: false, message: `Invalid mode: ${mode}. Must be explore, research, or commit.` };
+    }
+    this.intentMode = normalized;
+    this.minConfidence = thresholds[normalized];
+    console.log(`[PHASE] Intent mode set via tool: ${normalized} → minConfidence=${this.minConfidence}`);
+    if (this.onModeDetected) {
+      Promise.resolve(this.onModeDetected(normalized, this.minConfidence))
+        .catch(err => console.error('[PHASE] Mode callback error:', err.message));
+    }
+    return { ok: true, message: `Intent mode set to ${normalized} (confidence threshold: ${this.minConfidence}).` };
+  }
+
+  /**
    * Manually trigger a phase transition (from user clicking "Next Phase" button).
    * Bypasses AI detection but still respects the confidence gate if squeeze data exists.
    *

--- a/poc/server/phase-transition.js
+++ b/poc/server/phase-transition.js
@@ -12,14 +12,29 @@
  */
 
 /**
+ * Intent-mode → minimum confidence for advancing a phase (The Squeeze).
+ * Single source of truth for BOTH the tool path and the regex fallback.
+ */
+const MODE_THRESHOLDS = { explore: 5, research: 6, commit: 8 };
+
+/**
+ * After a toolTransition is BLOCKED by the confidence gate, suppress
+ * regex-detected forward transitions for this long — otherwise the AI
+ * narrating "we're not ready for phase 3 yet" (or similar) becomes an
+ * ungated side door seconds after the gate refused.
+ */
+const BLOCKED_SUPPRESSION_MS = 60 * 1000;
+
+/**
  * Patterns the AI uses to signal phase transitions.
  * Matched against AI transcript text (case-insensitive).
  */
 const TRANSITION_PATTERNS = [
   // Direct phase advancement signals
+  // (negative lookbehind: "we're NOT ready for phase 3" must not advance)
   /let'?s move (?:on )?to phase (\d)/i,
   /moving (?:on )?to phase (\d)/i,
-  /ready for phase (\d)/i,
+  /(?<!not )(?<!n't )ready for phase (\d)/i,
   /time for phase (\d)/i,
   /on to phase (\d)/i,
 
@@ -79,6 +94,10 @@ class PhaseTransitionHandler {
     this.lastTransitionAt = 0;
     this.debounceMs = 5000; // 5 seconds
 
+    // Timestamp of the last confidence-gate block — suppresses regex-detected
+    // forward transitions so narration can't sidestep a blocked advance_phase
+    this.lastBlockedAt = 0;
+
     // Track extracted confidence data (if the AI states it voluntarily)
     this.pendingSqueeze = null;
   }
@@ -104,8 +123,7 @@ class PhaseTransitionHandler {
       const modeMatch = combined.match(/\[MODE:(explore|research|commit)\]/i);
       if (modeMatch) {
         this.intentMode = modeMatch[1].toLowerCase();
-        const thresholds = { explore: 5, research: 6, commit: 8 };
-        this.minConfidence = thresholds[this.intentMode] || 6;
+        this.minConfidence = MODE_THRESHOLDS[this.intentMode] || 6;
         console.log(`[PHASE] Intent mode detected: ${this.intentMode} → minConfidence=${this.minConfidence}`);
         if (this.onModeDetected) {
           Promise.resolve(this.onModeDetected(this.intentMode, this.minConfidence))
@@ -132,6 +150,20 @@ class PhaseTransitionHandler {
     // NOTE: Squeeze injection disabled — Gemini AUDIO-only mode rejects text clientContent.
     // The AI's system prompt tells it to state confidence before transitioning.
     const transitionConfidence = this.pendingSqueeze?.confidence ?? confidence ?? null;
+
+    // The regex fallback must respect the same confidence gate as the tool
+    // path — it exists for narrated transitions, not as a side door.
+    if (targetPhase > currentPhase) {
+      if (now - this.lastBlockedAt < BLOCKED_SUPPRESSION_MS) {
+        console.log('[PHASE] Regex transition suppressed — advance_phase was gate-blocked moments ago');
+        return null;
+      }
+      if (transitionConfidence !== null && transitionConfidence < this.minConfidence) {
+        console.log(`[PHASE] Regex transition gated: confidence ${transitionConfidence} < required ${this.minConfidence}`);
+        return null;
+      }
+    }
+
     return this._fireTransition(currentPhase, targetPhase, transitionConfidence);
   }
 
@@ -252,6 +284,7 @@ class PhaseTransitionHandler {
     // The Squeeze — confidence gate, enforced deterministically.
     // Only gate FORWARD movement; going back to revisit a phase is always allowed.
     if (toPhase > currentPhase && confidence < this.minConfidence) {
+      this.lastBlockedAt = Date.now(); // arms regex-fallback suppression too
       return {
         ok: false,
         blocked: true,
@@ -294,12 +327,19 @@ class PhaseTransitionHandler {
    */
   toolSetMode(mode) {
     const normalized = String(mode || '').toLowerCase().trim();
-    const thresholds = { explore: 5, research: 6, commit: 8 };
-    if (!(normalized in thresholds)) {
+    if (!(normalized in MODE_THRESHOLDS)) {
       return { ok: false, message: `Invalid mode: ${mode}. Must be explore, research, or commit.` };
     }
+    // Once a mode is set, the threshold can only RISE — otherwise a blocked
+    // transition could be laundered by downgrading commit → explore.
+    if (this.intentMode && MODE_THRESHOLDS[normalized] < this.minConfidence) {
+      return {
+        ok: false,
+        message: `Intent mode is already ${this.intentMode} (threshold ${this.minConfidence}); it cannot be lowered mid-session. Continue at the current bar.`,
+      };
+    }
     this.intentMode = normalized;
-    this.minConfidence = thresholds[normalized];
+    this.minConfidence = MODE_THRESHOLDS[normalized];
     console.log(`[PHASE] Intent mode set via tool: ${normalized} → minConfidence=${this.minConfidence}`);
     if (this.onModeDetected) {
       Promise.resolve(this.onModeDetected(normalized, this.minConfidence))
@@ -349,4 +389,4 @@ class PhaseTransitionHandler {
   }
 }
 
-module.exports = { PhaseTransitionHandler, PHASE_NAME_TO_NUMBER };
+module.exports = { PhaseTransitionHandler, PHASE_NAME_TO_NUMBER, MODE_THRESHOLDS };

--- a/poc/server/session-tools.js
+++ b/poc/server/session-tools.js
@@ -1,0 +1,67 @@
+/**
+ * Session control tools — structured signaling between the AI and the server.
+ *
+ * The model talks to the HUMAN in audio, but signals the MACHINE through
+ * function calls. Previously phase transitions and intent mode were detected
+ * by regex over voice transcripts ("let's move to phase 2", "[MODE:commit]"),
+ * which is lossy: transcription mangles tags and phrasing varies. Tool calls
+ * are exact, and the tool RESPONSE feeds back into the conversation — so a
+ * blocked transition ("confidence 5 < required 8") is something the AI hears
+ * and acts on, closing the loop on the confidence gate.
+ *
+ * The regex path in phase-transition.js remains as a fallback for models
+ * that narrate instead of calling tools.
+ */
+
+const SESSION_CONTROL_DECLARATIONS = [
+  {
+    name: 'advance_phase',
+    description:
+      'Advance the session to the next phase (or jump to a specific phase) when you judge the current phase complete. ' +
+      'This is a silent control signal — never announce the tool call aloud. ' +
+      'If the response says "blocked", your confidence is below the required threshold: keep working the current phase, then retry.',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        to_phase: {
+          type: 'INTEGER',
+          description: 'Target phase number 0-7 (0=User Stories, 1=MINE, 2=SCOUT, 3=ASSAY, 4=CRUCIBLE, 5=AUDITOR, 6=PLAN, 7=VERIFY)',
+        },
+        confidence: {
+          type: 'INTEGER',
+          description: 'Your confidence 1-10 that the current phase achieved its goal. Be honest — low confidence blocks the transition, which is the system working as designed.',
+        },
+        carry_forward: {
+          type: 'STRING',
+          description: '3-5 sentence summary of this phase\'s findings, written for your future self in the next phase: root cause, key constraints, decisions made, open questions.',
+        },
+        reason: {
+          type: 'STRING',
+          description: 'One sentence: why this phase is complete.',
+        },
+      },
+      required: ['to_phase', 'confidence', 'carry_forward'],
+    },
+  },
+  {
+    name: 'set_intent_mode',
+    description:
+      'Declare the user\'s intent mode once you detect it (within the first 2-3 exchanges). ' +
+      'Silent control signal — confirm the mode to the user in speech, but never mention the tool. ' +
+      'Adjusts the confidence threshold for phase transitions: explore=5, research=6, commit=8.',
+    parameters: {
+      type: 'OBJECT',
+      properties: {
+        mode: {
+          type: 'STRING',
+          description: 'One of: explore (just thinking, wide and light), research (structured analysis), commit (a real decision with a deadline).',
+        },
+      },
+      required: ['mode'],
+    },
+  },
+];
+
+const SESSION_CONTROL_TOOL_NAMES = new Set(SESSION_CONTROL_DECLARATIONS.map((d) => d.name));
+
+module.exports = { SESSION_CONTROL_DECLARATIONS, SESSION_CONTROL_TOOL_NAMES };

--- a/tests/smoke/smoke.mjs
+++ b/tests/smoke/smoke.mjs
@@ -73,6 +73,24 @@ async function checkFrontend() {
   } catch {
     return record('frontend page load', false, 'playwright-core not installed (npm install)');
   }
+  // The plain-fetch fallback exists ONLY for environments where the browser
+  // itself can't run or can't reach the network (missing binary, sandbox TLS
+  // interception). Real page failures — timeouts, crashes, blank app — must
+  // stay failures, or the smoke test green-lights a broken deploy.
+  const envBlocked = (msg) =>
+    /ERR_CONNECTION_RESET|ERR_PROXY|ERR_TUNNEL|ERR_CERT|executable doesn't exist|Failed to launch/i.test(msg);
+  const fetchFallback = async (reason) => {
+    try {
+      const res = await fetch(FRONTEND_URL, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+      const html = await res.text();
+      const looksLikeApp = res.ok && html.includes('<div id="root">');
+      record('frontend HTTP (no-browser fallback)', looksLikeApp,
+        `HTTP ${res.status}; browser check unavailable here (${reason}) — run in CI or locally for console/render checks`);
+    } catch (fetchErr) {
+      record('frontend page load', false, `${reason}; fetch fallback also failed: ${fetchErr.message}`);
+    }
+  };
+
   let browser;
   try {
     const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
@@ -80,6 +98,11 @@ async function checkFrontend() {
       executablePath: process.env.CHROMIUM_PATH || '/opt/pw-browsers/chromium',
       ...(proxy ? { proxy: { server: proxy } } : {}),
     });
+  } catch (err) {
+    return fetchFallback(`browser launch failed: ${err.message.split('\n')[0]}`);
+  }
+
+  try {
     const page = await browser.newPage();
     const consoleErrors = [];
     page.on('console', (msg) => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
@@ -94,17 +117,11 @@ async function checkFrontend() {
     record('frontend console clean', consoleErrors.length === 0,
       consoleErrors.length ? consoleErrors.slice(0, 3).join(' | ').slice(0, 300) : '');
   } catch (err) {
-    // Some sandboxed environments block browser TLS but allow plain fetch —
-    // downgrade to an HTTP-only check rather than reporting a false failure.
     const reason = err.message.split('\n')[0];
-    try {
-      const res = await fetch(FRONTEND_URL, { signal: AbortSignal.timeout(TIMEOUT_MS) });
-      const html = await res.text();
-      const looksLikeApp = res.ok && html.includes('<div id="root">');
-      record('frontend HTTP (no-browser fallback)', looksLikeApp,
-        `HTTP ${res.status}; browser check unavailable here (${reason}) — run in CI or locally for console/render checks`);
-    } catch (fetchErr) {
-      record('frontend page load', false, `${reason}; fetch fallback also failed: ${fetchErr.message}`);
+    if (envBlocked(reason)) {
+      await fetchFallback(`browser blocked by environment: ${reason}`);
+    } else {
+      record('frontend page load', false, reason); // real failure — no fallback
     }
   } finally {
     await browser?.close();

--- a/tests/smoke/smoke.mjs
+++ b/tests/smoke/smoke.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Smoke test — verifies the deployed (or local) Thinking Foundry stack is alive.
+ * Covers the automatable half of issue #175 (full voice round-trip still needs a human + mic).
+ *
+ * Checks:
+ *   1. Backend /health responds 200 and reports status
+ *   2. Backend accepts a WebSocket handshake
+ *   3. Frontend loads in headless Chromium with zero console errors
+ *
+ * Usage:
+ *   node tests/smoke/smoke.mjs                          # against production
+ *   BACKEND_URL=http://localhost:3100 node tests/smoke/smoke.mjs
+ *   SKIP_FRONTEND=1 node tests/smoke/smoke.mjs          # backend-only
+ */
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+const BACKEND_URL = process.env.BACKEND_URL || 'https://thinking-foundry-production.up.railway.app';
+const FRONTEND_URL = process.env.FRONTEND_URL || 'https://frontend-jet-psi-12.vercel.app';
+const WS_URL = process.env.WS_URL || BACKEND_URL.replace(/^http/, 'ws');
+const TIMEOUT_MS = 30_000;
+
+const results = [];
+const record = (name, ok, detail = '') => {
+  results.push({ name, ok, detail });
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+async function checkHealth() {
+  try {
+    const res = await fetch(`${BACKEND_URL}/health`, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (!res.ok) return record('backend /health', false, `HTTP ${res.status}`);
+    const body = await res.json();
+    const failing = Object.entries(body.checks || {})
+      .filter(([, v]) => (typeof v === 'object' ? !v.ok : !v))
+      .map(([k]) => k);
+    record('backend /health', true, `status=${body.status}${failing.length ? `, failing: ${failing.join(', ')}` : ''}`);
+  } catch (err) {
+    record('backend /health', false, err.message);
+  }
+}
+
+async function checkWebSocket() {
+  const WebSocket = require('ws');
+  await new Promise((resolve) => {
+    const ws = new WebSocket(WS_URL);
+    const timer = setTimeout(() => {
+      record('backend WebSocket handshake', false, `no open event within ${TIMEOUT_MS / 1000}s`);
+      ws.terminate();
+      resolve();
+    }, TIMEOUT_MS);
+    ws.on('open', () => {
+      clearTimeout(timer);
+      record('backend WebSocket handshake', true, WS_URL);
+      ws.close();
+      resolve();
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      record('backend WebSocket handshake', false, err.message);
+      resolve();
+    });
+  });
+}
+
+async function checkFrontend() {
+  if (process.env.SKIP_FRONTEND) return;
+  let chromium;
+  try {
+    ({ chromium } = require('playwright-core'));
+  } catch {
+    return record('frontend page load', false, 'playwright-core not installed (npm install)');
+  }
+  let browser;
+  try {
+    const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+    browser = await chromium.launch({
+      executablePath: process.env.CHROMIUM_PATH || '/opt/pw-browsers/chromium',
+      ...(proxy ? { proxy: { server: proxy } } : {}),
+    });
+    const page = await browser.newPage();
+    const consoleErrors = [];
+    page.on('console', (msg) => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+    page.on('pageerror', (err) => consoleErrors.push(String(err)));
+
+    const res = await page.goto(FRONTEND_URL, { waitUntil: 'networkidle', timeout: TIMEOUT_MS });
+    record('frontend HTTP status', res.status() === 200, `HTTP ${res.status()}`);
+
+    const rendered = await page.locator('#root > *').count();
+    record('frontend renders app', rendered > 0, rendered > 0 ? '' : '#root is empty');
+
+    record('frontend console clean', consoleErrors.length === 0,
+      consoleErrors.length ? consoleErrors.slice(0, 3).join(' | ').slice(0, 300) : '');
+  } catch (err) {
+    // Some sandboxed environments block browser TLS but allow plain fetch —
+    // downgrade to an HTTP-only check rather than reporting a false failure.
+    const reason = err.message.split('\n')[0];
+    try {
+      const res = await fetch(FRONTEND_URL, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+      const html = await res.text();
+      const looksLikeApp = res.ok && html.includes('<div id="root">');
+      record('frontend HTTP (no-browser fallback)', looksLikeApp,
+        `HTTP ${res.status}; browser check unavailable here (${reason}) — run in CI or locally for console/render checks`);
+    } catch (fetchErr) {
+      record('frontend page load', false, `${reason}; fetch fallback also failed: ${fetchErr.message}`);
+    }
+  } finally {
+    await browser?.close();
+  }
+}
+
+console.log(`Smoke test\n  backend:  ${BACKEND_URL}\n  frontend: ${FRONTEND_URL}\n`);
+await checkHealth();
+await checkWebSocket();
+await checkFrontend();
+
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+process.exit(failed.length ? 1 : 0);

--- a/tests/unit/context-manager.test.mjs
+++ b/tests/unit/context-manager.test.mjs
@@ -61,6 +61,25 @@ describe('ContextManager', () => {
     expect(cm.getCondensedContext()).toBe('');
   });
 
+  it('getSessionBullets works for SHORT sessions (below the 10-utterance eviction window)', () => {
+    const cm = new ContextManager();
+    cm.addUtterance('user', 'I want to decide whether to raise money or bootstrap for another year.');
+    cm.addUtterance('assistant', 'What would taking the money let you do that you cannot do now?');
+    const bullets = cm.getSessionBullets(5);
+    expect(bullets.length).toBeGreaterThan(0); // old keyPoints-only path returned []
+    expect(bullets.some((b) => b.includes('raise money'))).toBe(true);
+  });
+
+  it('getSessionBullets combines evicted key points with the live window, capped at n', () => {
+    const cm = new ContextManager();
+    for (let i = 0; i < 14; i++) {
+      cm.addUtterance('user', `A sufficiently long statement about the decision, number ${i}.`);
+    }
+    const bullets = cm.getSessionBullets(5);
+    expect(bullets).toHaveLength(5);
+    expect(bullets[4]).toContain('number 13'); // includes the most recent, un-evicted turns
+  });
+
   it('getFullTranscript formats speakers as User/Foundry', () => {
     const cm = new ContextManager();
     cm.addUtterance('user', 'Hello.');

--- a/tests/unit/context-manager.test.mjs
+++ b/tests/unit/context-manager.test.mjs
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { ContextManager } = require('../../poc/server/context-manager.js');
+
+describe('ContextManager', () => {
+  it('records utterances in full transcript and rolling window', () => {
+    const cm = new ContextManager();
+    cm.addUtterance('user', 'I want to quit my job and start a company.');
+    cm.addUtterance('assistant', 'What makes you sure the job is the problem?');
+    expect(cm.fullTranscript).toHaveLength(2);
+    expect(cm.recentExchanges).toHaveLength(2);
+  });
+
+  it('trims the rolling window to 10 and extracts key points from evicted entries', () => {
+    const cm = new ContextManager();
+    for (let i = 0; i < 12; i++) {
+      cm.addUtterance('assistant', `Question number ${i}: what would happen if you waited a year?`);
+    }
+    expect(cm.recentExchanges).toHaveLength(10);
+    expect(cm.fullTranscript).toHaveLength(12);
+    // Two evicted assistant questions become key points
+    expect(cm.keyPoints).toHaveLength(2);
+    expect(cm.keyPoints[0].text).toContain('Question number 0');
+  });
+
+  it('ignores short evicted utterances when extracting key points', () => {
+    const cm = new ContextManager();
+    cm.extractKeyPoint({ role: 'assistant', text: 'Okay.', timestamp: 't' });
+    cm.extractKeyPoint({ role: 'user', text: 'Yes.', timestamp: 't' });
+    expect(cm.keyPoints).toHaveLength(0);
+  });
+
+  it('caps key points at 20 and trims to the most recent 15', () => {
+    const cm = new ContextManager();
+    for (let i = 0; i < 21; i++) {
+      cm.extractKeyPoint({ role: 'user', text: `A sufficiently long user statement number ${i}.`, timestamp: 't' });
+    }
+    expect(cm.keyPoints).toHaveLength(15);
+    expect(cm.keyPoints[14].text).toContain('number 20');
+  });
+
+  it('getCondensedContext includes phase outputs, key points, and recent turns', () => {
+    const cm = new ContextManager();
+    cm.setPhaseOutput(1, 'Root cause: fear of irrelevance, not the salary.');
+    cm.addUtterance('user', 'I keep coming back to the same doubt about timing and money.');
+    cm.addUtterance('assistant', 'What if the timing question is actually a courage question?');
+    cm.extractKeyPoint({ role: 'user', text: 'The real issue is I have 8 months of runway.', timestamp: 't' });
+
+    const ctx = cm.getCondensedContext();
+    expect(ctx).toContain('PHASE RESULTS SO FAR:');
+    expect(ctx).toContain('Root cause: fear of irrelevance');
+    expect(ctx).toContain('KEY POINTS FROM CONVERSATION:');
+    expect(ctx).toContain('RECENT CONVERSATION:');
+    expect(ctx).toContain('You: What if the timing question');
+  });
+
+  it('getCondensedContext is empty for a fresh session', () => {
+    const cm = new ContextManager();
+    expect(cm.getCondensedContext()).toBe('');
+  });
+
+  it('getFullTranscript formats speakers as User/Foundry', () => {
+    const cm = new ContextManager();
+    cm.addUtterance('user', 'Hello.');
+    cm.addUtterance('assistant', 'What decision brought you here?');
+    const t = cm.getFullTranscript();
+    expect(t).toContain('**User**');
+    expect(t).toContain('**Foundry**');
+  });
+});

--- a/tests/unit/email-auth.test.mjs
+++ b/tests/unit/email-auth.test.mjs
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { EmailAuth } = require('../../poc/server/email-auth.js');
+
+// Constructor registers a cleanup setInterval — fake timers keep tests hermetic.
+describe('EmailAuth', () => {
+  let auth;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    auth = new EmailAuth({ resendApiKey: null, baseUrl: 'http://localhost' });
+  });
+  afterEach(() => vi.useRealTimers());
+
+  describe('session nonces (#176 regression)', () => {
+    it('nonce is valid within 5 minutes (survives Railway cold start)', () => {
+      const nonce = auth.createSessionNonce('roderic@example.com');
+      vi.advanceTimersByTime(4 * 60 * 1000); // 4 min — longer than any cold start
+      expect(auth.verifySessionNonce(nonce)).toBe('roderic@example.com');
+    });
+
+    it('nonce expires after 5 minutes', () => {
+      const nonce = auth.createSessionNonce('roderic@example.com');
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(auth.verifySessionNonce(nonce)).toBeNull();
+    });
+
+    it('nonce is one-time use', () => {
+      const nonce = auth.createSessionNonce('roderic@example.com');
+      expect(auth.verifySessionNonce(nonce)).toBe('roderic@example.com');
+      expect(auth.verifySessionNonce(nonce)).toBeNull();
+    });
+
+    it('unknown nonce is rejected', () => {
+      expect(auth.verifySessionNonce('not-a-real-nonce')).toBeNull();
+    });
+
+    it('email is normalized to lowercase', () => {
+      const nonce = auth.createSessionNonce('RODERIC@Example.COM');
+      expect(auth.verifySessionNonce(nonce)).toBe('roderic@example.com');
+    });
+  });
+
+  describe('whitelist', () => {
+    it('add/remove normalizes and deduplicates', async () => {
+      await auth.addAllowedEmail('  Founder@Startup.io ');
+      await auth.addAllowedEmail('founder@startup.io');
+      expect(auth.getAllowedEmails()).toEqual(['founder@startup.io']);
+      await auth.removeAllowedEmail('FOUNDER@startup.io');
+      expect(auth.getAllowedEmails()).toEqual([]);
+    });
+
+    it('loads ALLOWED_EMAILS from env', () => {
+      vi.stubEnv('ALLOWED_EMAILS', 'a@x.com, B@Y.com');
+      const envAuth = new EmailAuth({ resendApiKey: null });
+      expect(envAuth.getAllowedEmails().sort()).toEqual(['a@x.com', 'b@y.com']);
+      vi.unstubAllEnvs();
+    });
+  });
+
+  describe('PIN flow', () => {
+    it('rejects malformed PINs', async () => {
+      for (const bad of ['123', '12345', 'abcd', '', undefined]) {
+        const res = await auth.setPin('u@x.com', bad);
+        expect(res.success).toBe(false);
+      }
+    });
+
+    it('setPin issues device token + nonce; verifyPin accepts the right PIN', async () => {
+      const set = await auth.setPin('u@x.com', '4242');
+      expect(set.success).toBe(true);
+      expect(set.deviceToken).toBeTruthy();
+      expect(auth.verifySessionNonce(set.sessionNonce)).toBe('u@x.com');
+
+      const ok = await auth.verifyPin(set.deviceToken, '4242');
+      expect(ok.valid).toBe(true);
+      expect(ok.email).toBe('u@x.com');
+      expect(auth.verifySessionNonce(ok.sessionNonce)).toBe('u@x.com');
+    });
+
+    it('verifyPin rejects wrong PIN and unknown device', async () => {
+      const set = await auth.setPin('u@x.com', '4242');
+      expect((await auth.verifyPin(set.deviceToken, '0000')).valid).toBe(false);
+      expect((await auth.verifyPin('bogus-device', '4242')).valid).toBe(false);
+    });
+  });
+
+  describe('magic link cleanup', () => {
+    it('removes expired links from memory', () => {
+      auth.magicLinks.set('t1', { email: 'a@x.com', expiresAt: Date.now() - 1 });
+      auth.magicLinks.set('t2', { email: 'b@x.com', expiresAt: Date.now() + 60_000 });
+      auth._cleanupExpiredLinks();
+      expect(auth.magicLinks.has('t1')).toBe(false);
+      expect(auth.magicLinks.has('t2')).toBe(true);
+    });
+  });
+});

--- a/tests/unit/gemini-live.test.mjs
+++ b/tests/unit/gemini-live.test.mjs
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { GeminiLiveManager } = require('../../poc/server/gemini-live.js');
+
+class FakeWs extends EventEmitter {
+  constructor() {
+    super();
+    this.readyState = 1; // WebSocket.OPEN
+    this.sent = [];
+  }
+  send(msg) { this.sent.push(JSON.parse(msg)); }
+  close(code, reason) {
+    this.readyState = 3;
+    this.emit('close', code, String(reason || ''));
+  }
+}
+
+const lastSetup = (ws) => ws.sent.filter((m) => m.setup).pop()?.setup;
+
+describe('GeminiLiveManager — native session resumption', () => {
+  let mgr;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mgr = new GeminiLiveManager({ apiKey: 'test-key' });
+  });
+  afterEach(() => {
+    mgr.close();
+    vi.useRealTimers();
+  });
+
+  it('setup opts into sessionResumption and contextWindowCompression by default', () => {
+    const ws = new FakeWs();
+    mgr.sendSetup(ws, 0, '');
+    const setup = lastSetup(ws);
+    expect(setup.sessionResumption).toEqual({});
+    expect(setup.contextWindowCompression).toEqual({ slidingWindow: {} });
+    expect(setup.generationConfig.responseModalities).toEqual(['AUDIO']); // must stay AUDIO-only
+  });
+
+  it('can be disabled via option (kill switch)', () => {
+    const off = new GeminiLiveManager({ apiKey: 'k', nativeResumption: false });
+    const ws = new FakeWs();
+    off.sendSetup(ws, 0, '');
+    const setup = lastSetup(ws);
+    expect(setup.sessionResumption).toBeUndefined();
+    expect(setup.contextWindowCompression).toBeUndefined();
+  });
+
+  it('stores resumption handles and reuses the latest on the next setup', () => {
+    const ws = new FakeWs();
+    mgr.activeWs = ws;
+    mgr.wireHandlers(ws, false);
+
+    ws.emit('message', JSON.stringify({ sessionResumptionUpdate: { newHandle: 'h1', resumable: true } }));
+    ws.emit('message', JSON.stringify({ sessionResumptionUpdate: { newHandle: 'h2', resumable: true } }));
+    // non-resumable updates must not clobber the last good handle
+    ws.emit('message', JSON.stringify({ sessionResumptionUpdate: { newHandle: 'bad', resumable: false } }));
+    expect(mgr.resumptionHandle).toBe('h2');
+
+    const next = new FakeWs();
+    mgr.sendSetup(next, 1, 'context');
+    expect(lastSetup(next).sessionResumption).toEqual({ handle: 'h2' });
+  });
+
+  it('parses protobuf durations in both wire formats', () => {
+    expect(mgr._parseDuration('10s')).toBe(10000);
+    expect(mgr._parseDuration('2.5s')).toBe(2500);
+    expect(mgr._parseDuration({ seconds: 3, nanos: 500000000 })).toBe(3500);
+    expect(mgr._parseDuration(undefined)).toBeNull();
+    expect(mgr._parseDuration('weird')).toBeNull();
+  });
+
+  it('GoAway triggers an early swap once the standby completes setup', () => {
+    const active = new FakeWs();
+    mgr.activeWs = active;
+    mgr.connectionStartTime = Date.now();
+    mgr.wireHandlers(active, false);
+
+    const created = [];
+    mgr.createConnection = () => { const f = new FakeWs(); created.push(f); return f; };
+    const onReconnecting = vi.fn();
+    const onReconnected = vi.fn();
+    mgr.onReconnecting = onReconnecting;
+    mgr.onReconnected = onReconnected;
+
+    active.emit('message', JSON.stringify({ goAway: { timeLeft: '8s' } }));
+
+    expect(onReconnecting).toHaveBeenCalled();
+    expect(created).toHaveLength(1);
+    const standby = created[0];
+
+    standby.emit('open');
+    expect(lastSetup(standby)).toBeTruthy(); // setup sent on open
+    standby.emit('message', JSON.stringify({ setupComplete: {} }));
+
+    vi.advanceTimersByTime(150); // poll notices setupComplete
+    expect(mgr.activeWs).toBe(standby);
+    expect(onReconnected).toHaveBeenCalled(); // old ws closed → swap finished
+    expect(active.readyState).toBe(3);
+  });
+
+  it('GoAway swaps at the deadline even if setupComplete never arrives', () => {
+    const active = new FakeWs();
+    mgr.activeWs = active;
+    mgr.connectionStartTime = Date.now();
+    mgr.wireHandlers(active, false);
+    mgr.createConnection = () => new FakeWs();
+    mgr.forceReconnect = vi.fn(); // performSwap falls back here if standby isn't OPEN
+
+    active.emit('message', JSON.stringify({ goAway: { timeLeft: '2s' } }));
+    vi.advanceTimersByTime(2000);
+    // Standby was created and is OPEN (FakeWs default), so a real swap happens
+    expect(mgr.activeWs).not.toBe(active);
+  });
+
+  it('close() during a GoAway swap does not throw or fire callbacks', () => {
+    const active = new FakeWs();
+    mgr.activeWs = active;
+    mgr.connectionStartTime = Date.now();
+    mgr.wireHandlers(active, false);
+    mgr.createConnection = () => new FakeWs();
+
+    active.emit('message', JSON.stringify({ goAway: { timeLeft: '5s' } }));
+    mgr.close();
+    expect(() => vi.advanceTimersByTime(10000)).not.toThrow();
+  });
+});

--- a/tests/unit/gemini-live.test.mjs
+++ b/tests/unit/gemini-live.test.mjs
@@ -103,18 +103,98 @@ describe('GeminiLiveManager — native session resumption', () => {
     expect(active.readyState).toBe(3);
   });
 
-  it('GoAway swaps at the deadline even if setupComplete never arrives', () => {
+  it('GoAway deadline without setupComplete falls back to forceReconnect — never swaps onto a pre-setup connection', () => {
     const active = new FakeWs();
     mgr.activeWs = active;
     mgr.connectionStartTime = Date.now();
     mgr.wireHandlers(active, false);
     mgr.createConnection = () => new FakeWs();
-    mgr.forceReconnect = vi.fn(); // performSwap falls back here if standby isn't OPEN
+    mgr.forceReconnect = vi.fn();
 
     active.emit('message', JSON.stringify({ goAway: { timeLeft: '2s' } }));
     vi.advanceTimersByTime(2000);
-    // Standby was created and is OPEN (FakeWs default), so a real swap happens
-    expect(mgr.activeWs).not.toBe(active);
+    // Standby socket is OPEN but its setup was never acknowledged — swapping
+    // would route audio to a pre-setup connection, so we must NOT swap.
+    expect(mgr.activeWs).toBe(active);
+    expect(mgr.forceReconnect).toHaveBeenCalled();
+  });
+
+  it('audio, barge-in, and GoAway keep working on a PROMOTED connection (stale-flag regression)', () => {
+    const onAudio = vi.fn();
+    const onInterrupted = vi.fn();
+    mgr.onAudio = onAudio;
+    mgr.onInterrupted = onInterrupted;
+
+    // Wire a socket as STANDBY, then promote it the way performSwap does
+    const promoted = new FakeWs();
+    mgr.standbyWs = promoted;
+    mgr.wireHandlers(promoted, true);
+    mgr.activeWs = promoted;
+    mgr.standbyWs = null;
+    mgr.isSwapping = false;
+    mgr.connectionStartTime = Date.now();
+
+    promoted.emit('message', JSON.stringify({ serverContent: { modelTurn: { parts: [{ inlineData: { data: 'QUJD' } }] }, interrupted: true } }));
+    expect(onAudio).toHaveBeenCalledWith('QUJD'); // was dropped by the old !isStandby gating
+    expect(onInterrupted).toHaveBeenCalled();
+
+    mgr.createConnection = () => new FakeWs();
+    promoted.emit('message', JSON.stringify({ goAway: { timeLeft: '8s' } }));
+    expect(mgr.standbyWs).not.toBeNull(); // GoAway handled on promoted socket
+  });
+
+  it('GoAway closes a pre-existing scheduled standby instead of orphaning it', () => {
+    const active = new FakeWs();
+    mgr.activeWs = active;
+    mgr.connectionStartTime = Date.now();
+    mgr.wireHandlers(active, false);
+
+    const scheduledStandby = new FakeWs();
+    mgr.standbyWs = scheduledStandby;
+    mgr.wireHandlers(scheduledStandby, true);
+    mgr.createConnection = () => new FakeWs();
+
+    active.emit('message', JSON.stringify({ goAway: { timeLeft: '8s' } }));
+    expect(scheduledStandby.readyState).toBe(3); // closed, not leaked
+    expect(mgr.standbyWs).not.toBe(scheduledStandby);
+
+    // The orphan's late setupComplete must NOT arm the swap flag
+    scheduledStandby.readyState = 1;
+    scheduledStandby.emit('message', JSON.stringify({ setupComplete: {} }));
+    expect(mgr.standbySetupComplete).toBe(false);
+  });
+
+  it('resumption handles are only accepted from the ACTIVE connection', () => {
+    const active = new FakeWs();
+    const standby = new FakeWs();
+    mgr.activeWs = active;
+    mgr.standbyWs = standby;
+    mgr.wireHandlers(active, false);
+    mgr.wireHandlers(standby, true);
+
+    active.emit('message', JSON.stringify({ sessionResumptionUpdate: { newHandle: 'active-h', resumable: true } }));
+    standby.emit('message', JSON.stringify({ sessionResumptionUpdate: { newHandle: 'standby-h', resumable: true } }));
+    expect(mgr.resumptionHandle).toBe('active-h');
+  });
+
+  it('forceReconnect clears the resumption handle on phase change, keeps it same-phase', async () => {
+    mgr.resumptionHandle = 'h-old';
+    mgr.phase = 1;
+    const fresh = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => fresh.emit('open'), 0); return fresh; };
+
+    const p = mgr.forceReconnect(2, 'ctx'); // phase change
+    await vi.advanceTimersByTimeAsync(10);
+    await p;
+    expect(mgr.resumptionHandle).toBeNull();
+
+    mgr.resumptionHandle = 'h-same';
+    const fresh2 = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => fresh2.emit('open'), 0); return fresh2; };
+    const p2 = mgr.forceReconnect(2, 'ctx'); // same phase (swap-failure fallback)
+    await vi.advanceTimersByTimeAsync(10);
+    await p2;
+    expect(mgr.resumptionHandle).toBe('h-same');
   });
 
   it('close() during a GoAway swap does not throw or fire callbacks', () => {

--- a/tests/unit/hot-memory.test.mjs
+++ b/tests/unit/hot-memory.test.mjs
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRequire } from 'module';
+import { mkdtempSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const require = createRequire(import.meta.url);
+const { HotMemory, MAX_SESSIONS } = require('../../poc/server/hot-memory.js');
+
+describe('HotMemory (hot.md — #169)', () => {
+  let hot, filePath;
+
+  beforeEach(() => {
+    filePath = join(mkdtempSync(join(tmpdir(), 'hot-')), 'hot.md');
+    hot = new HotMemory({ filePath });
+  });
+
+  it('read returns empty string when hot.md does not exist', () => {
+    expect(hot.read()).toBe('');
+    expect(hot.getPromptContext()).toBe('');
+  });
+
+  it('appendSession writes a session entry with bullets', () => {
+    const ok = hot.appendSession({
+      endedAt: '2026-07-12T10:00:00Z',
+      phaseReached: 4,
+      bullets: ['Root cause: pricing fear, not product', 'Decided to test €99 tier'],
+    });
+    expect(ok).toBe(true);
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain('## Session 2026-07-12T10:00:00Z (phase reached: 4)');
+    expect(content).toContain('- Root cause: pricing fear, not product');
+  });
+
+  it('skips writing when there are no meaningful bullets', () => {
+    expect(hot.appendSession({ endedAt: 'x', bullets: ['', '   '] })).toBe(false);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it('keeps only the newest MAX_SESSIONS entries, newest first', () => {
+    for (let i = 1; i <= 5; i++) {
+      hot.appendSession({ endedAt: `2026-07-0${i}T00:00:00Z`, bullets: [`takeaway ${i}`] });
+    }
+    const entries = hot._parseEntries(hot.read());
+    expect(entries).toHaveLength(MAX_SESSIONS);
+    expect(entries[0]).toContain('2026-07-05');
+    expect(entries[2]).toContain('2026-07-03');
+    expect(hot.read()).not.toContain('takeaway 1');
+  });
+
+  it('caps bullets at 5 and truncates long ones', () => {
+    hot.appendSession({
+      endedAt: 't',
+      bullets: ['one', 'two', 'three', 'four', 'five', 'six', 'x'.repeat(500)],
+    });
+    const content = hot.read();
+    expect(content).toContain('- five');
+    expect(content).not.toContain('- six');
+    expect(content).not.toContain('x'.repeat(201));
+  });
+
+  it('normalizes whitespace inside bullets', () => {
+    hot.appendSession({ endedAt: 't', bullets: ['line\nbreaks   and   spaces'] });
+    expect(hot.read()).toContain('- line breaks and spaces');
+  });
+
+  it('getPromptContext formats entries for system-prompt injection', () => {
+    hot.appendSession({ endedAt: 't1', bullets: ['a decision was made'] });
+    const ctx = hot.getPromptContext();
+    expect(ctx).toContain('=== RECENT SESSIONS (hot memory) ===');
+    expect(ctx).toContain('- a decision was made');
+  });
+
+  it('survives hand-edited files (parses only ## Session blocks)', () => {
+    hot.appendSession({ endedAt: 't1', bullets: ['first'] });
+    // Simulate Roderic adding notes above the entries
+    const edited = hot.read().replace('# hot.md', '# hot.md\n\nMy manual note.\n');
+    require('fs').writeFileSync(filePath, edited);
+    hot.appendSession({ endedAt: 't2', bullets: ['second'] });
+    const entries = hot._parseEntries(hot.read());
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toContain('second');
+  });
+});

--- a/tests/unit/phase-transition.test.mjs
+++ b/tests/unit/phase-transition.test.mjs
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { PhaseTransitionHandler, PHASE_NAME_TO_NUMBER } = require('../../poc/server/phase-transition.js');
+
+describe('PhaseTransitionHandler', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const makeHandler = (opts = {}) => {
+    const onTransition = vi.fn();
+    const handler = new PhaseTransitionHandler({ onTransition, ...opts });
+    return { handler, onTransition };
+  };
+
+  it('detects "moving to phase N" and fires the callback', () => {
+    const { handler, onTransition } = makeHandler();
+    const result = handler.processAiUtterance("Great. Let's move to phase 2.", 1);
+    expect(result).toMatchObject({ transition: true, fromPhase: 1, toPhase: 2 });
+    expect(onTransition).toHaveBeenCalledWith(1, 2, expect.any(Object));
+  });
+
+  it('detects phase transitions by name', () => {
+    const { handler } = makeHandler();
+    const result = handler.processAiUtterance("Time for the Crucible.", 3);
+    expect(result).toMatchObject({ transition: true, toPhase: PHASE_NAME_TO_NUMBER.crucible });
+  });
+
+  it('"I have what I need for phase N" advances to N+1', () => {
+    const { handler } = makeHandler();
+    const result = handler.processAiUtterance('I have what I need for phase 0.', 0);
+    expect(result).toMatchObject({ transition: true, fromPhase: 0, toPhase: 1 });
+  });
+
+  it('generic completion signal advances to the next phase', () => {
+    const { handler } = makeHandler();
+    const result = handler.processAiUtterance("That's enough for this phase.", 4);
+    expect(result).toMatchObject({ transition: true, toPhase: 5 });
+  });
+
+  it('returns null for ordinary conversation', () => {
+    const { handler } = makeHandler();
+    expect(handler.processAiUtterance('Why do you think that is?', 1)).toBeNull();
+    expect(handler.processAiUtterance('Tell me more about your timeline.', 1)).toBeNull();
+  });
+
+  it('does not fire a transition to the current phase', () => {
+    const { handler, onTransition } = makeHandler();
+    expect(handler.processAiUtterance("Let's move to phase 2.", 2)).toBeNull();
+    expect(onTransition).not.toHaveBeenCalled();
+  });
+
+  it('debounces transitions within 5 seconds', () => {
+    const { handler, onTransition } = makeHandler();
+    handler.processAiUtterance("Moving to phase 1.", 0);
+    expect(handler.processAiUtterance("Moving to phase 2.", 1)).toBeNull();
+    vi.advanceTimersByTime(6000);
+    expect(handler.processAiUtterance("Moving to phase 2.", 1)).toMatchObject({ toPhase: 2 });
+    expect(onTransition).toHaveBeenCalledTimes(2);
+  });
+
+  it('extracts confidence stated before the transition (The Squeeze)', () => {
+    const { handler } = makeHandler();
+    handler.processAiUtterance('My confidence: 8/10 on this direction.', 1);
+    const result = handler.processAiUtterance("Let's move to phase 2.", 1);
+    expect(result.confidence).toBe(8);
+  });
+
+  it('detects intent mode and adjusts the confidence threshold', () => {
+    const onModeDetected = vi.fn();
+    const { handler } = makeHandler({ onModeDetected });
+    handler.processAiUtterance('Understood. [MODE:commit] This is a commitment decision.', 0);
+    expect(handler.intentMode).toBe('commit');
+    expect(handler.minConfidence).toBe(8);
+    expect(onModeDetected).toHaveBeenCalledWith('commit', 8);
+  });
+
+  it('manualTransition validates target phase and debounces', () => {
+    const { handler, onTransition } = makeHandler();
+    expect(handler.manualTransition(0, 9)).toMatchObject({ transition: false, blocked: true });
+    expect(handler.manualTransition(0, 1)).toMatchObject({ transition: true, toPhase: 1 });
+    expect(handler.manualTransition(1, 2)).toMatchObject({ transition: false, blocked: true });
+    expect(onTransition).toHaveBeenCalledTimes(1);
+    expect(onTransition).toHaveBeenCalledWith(0, 1, expect.objectContaining({ manual: true }));
+  });
+
+  it('buffers utterances so split transition signals still match', () => {
+    const { handler } = makeHandler();
+    handler.processAiUtterance("Good. Let's move", 1);
+    const result = handler.processAiUtterance('to phase 2 now.', 1);
+    expect(result).toMatchObject({ transition: true, toPhase: 2 });
+  });
+});

--- a/tests/unit/session-state.test.mjs
+++ b/tests/unit/session-state.test.mjs
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { SessionState, PHASES } = require('../../poc/server/session-state.js');
+
+describe('SessionState', () => {
+  it('starts at phase 0 with history recorded', () => {
+    const s = new SessionState();
+    expect(s.currentPhase).toBe(0);
+    expect(s.phaseHistory).toHaveLength(1);
+    expect(s.phaseHistory[0].phase).toBe(0);
+  });
+
+  it('setPhase moves to a valid phase and appends history', () => {
+    const s = new SessionState();
+    const info = s.setPhase(3);
+    expect(s.currentPhase).toBe(3);
+    expect(info).toMatchObject({ phase: 3, name: 'ASSAY', slug: 'assay' });
+    expect(s.phaseHistory).toHaveLength(2);
+  });
+
+  it('setPhase rejects out-of-range phases', () => {
+    const s = new SessionState();
+    expect(() => s.setPhase(-1)).toThrow(/Invalid phase/);
+    expect(() => s.setPhase(8)).toThrow(/Invalid phase/);
+  });
+
+  it('nextPhase clamps at 7, previousPhase clamps at 0', () => {
+    const s = new SessionState();
+    expect(s.previousPhase().phase).toBe(0);
+    s.setPhase(7);
+    expect(s.nextPhase().phase).toBe(7);
+    expect(s.phaseHistory.filter((h) => h.phase === 7)).toHaveLength(1);
+  });
+
+  it('nextPhase advances linearly through all 8 phases', () => {
+    const s = new SessionState();
+    for (let i = 1; i <= 7; i++) {
+      expect(s.nextPhase().phase).toBe(i);
+    }
+  });
+
+  it('getAllPhases reports visited and current flags', () => {
+    const s = new SessionState();
+    s.setPhase(2);
+    const all = s.getAllPhases();
+    expect(all).toHaveLength(8);
+    expect(all[2]).toMatchObject({ isCurrent: true, visited: true });
+    expect(all[0]).toMatchObject({ isCurrent: false, visited: true });
+    expect(all[5]).toMatchObject({ isCurrent: false, visited: false });
+  });
+
+  it('toJSON exposes a serializable snapshot', () => {
+    const s = new SessionState();
+    const json = s.toJSON();
+    expect(json.currentPhase).toBe(0);
+    expect(json.phaseInfo.name).toBe(PHASES[0].name);
+    expect(typeof json.durationSeconds).toBe('number');
+  });
+});

--- a/tests/unit/session-tools.test.mjs
+++ b/tests/unit/session-tools.test.mjs
@@ -85,6 +85,62 @@ describe('PhaseTransitionHandler.toolSetMode (set_intent_mode)', () => {
     expect(onModeDetected).toHaveBeenCalledWith('explore', 5);
     expect(handler.toolSetMode('yolo').ok).toBe(false);
   });
+
+  it('rejects threshold downgrades — blocked transitions cannot be laundered via explore mode', () => {
+    const handler = new PhaseTransitionHandler({});
+    handler.toolSetMode('commit');
+    const result = handler.toolSetMode('explore');
+    expect(result.ok).toBe(false);
+    expect(handler.minConfidence).toBe(8);
+    // raising is allowed
+    const handler2 = new PhaseTransitionHandler({});
+    handler2.toolSetMode('explore');
+    expect(handler2.toolSetMode('commit').ok).toBe(true);
+    expect(handler2.minConfidence).toBe(8);
+  });
+});
+
+describe('regex fallback respects the confidence gate (side-door regression)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('"we\'re not ready for phase 3" does NOT fire a transition', () => {
+    const onTransition = vi.fn();
+    const handler = new PhaseTransitionHandler({ onTransition });
+    expect(handler.processAiUtterance("We're not ready for phase 3 until we test pricing.", 2)).toBeNull();
+    expect(onTransition).not.toHaveBeenCalled();
+  });
+
+  it('narrated forward transitions are suppressed right after a gate-blocked advance_phase', () => {
+    const onTransition = vi.fn();
+    const handler = new PhaseTransitionHandler({ onTransition });
+    handler.toolSetMode('commit');
+    expect(handler.toolTransition(2, { to_phase: 3, confidence: 5, carry_forward: 'x' }).blocked).toBe(true);
+
+    // seconds later the AI narrates a transition — must stay suppressed
+    expect(handler.processAiUtterance("Okay, let's move to phase 3.", 2)).toBeNull();
+    expect(onTransition).not.toHaveBeenCalled();
+
+    // after the suppression window it works again
+    vi.advanceTimersByTime(61_000);
+    expect(handler.processAiUtterance("Let's move to phase 3.", 2)).toMatchObject({ toPhase: 3 });
+  });
+
+  it('regex path blocks forward advance when stated confidence is below the gate', () => {
+    const onTransition = vi.fn();
+    const handler = new PhaseTransitionHandler({ onTransition });
+    handler.toolSetMode('commit'); // threshold 8
+    handler.processAiUtterance('My confidence: 6/10 right now.', 1);
+    expect(handler.processAiUtterance("Moving to phase 2.", 1)).toBeNull();
+    expect(onTransition).not.toHaveBeenCalled();
+  });
+
+  it('going backwards is never gated', () => {
+    const handler = new PhaseTransitionHandler({ onTransition: vi.fn() });
+    handler.toolSetMode('commit');
+    handler.toolTransition(4, { to_phase: 5, confidence: 3, carry_forward: 'x' }); // blocked, arms suppression
+    expect(handler.toolTransition(4, { to_phase: 1, confidence: 2, carry_forward: 'revisit' }).ok).toBe(true);
+  });
 });
 
 describe('GeminiLiveManager control-tool routing', () => {
@@ -113,6 +169,24 @@ describe('GeminiLiveManager control-tool routing', () => {
     expect(onControlCall).toHaveBeenCalledWith({ name: 'advance_phase', args: { to_phase: 2, confidence: 9, carry_forward: 'done' } });
     const resp = ws.sent[0].toolResponse.functionResponses[0];
     expect(resp).toMatchObject({ id: 'c1', name: 'advance_phase', response: { result: 'Transition to phase 2 accepted.' } });
+    mgr.close();
+  });
+
+  it('a throwing control handler still gets a functionResponse (model must never stall)', async () => {
+    const onControlCall = vi.fn(() => { throw new Error('phaseHandler exploded'); });
+    const mgr = new GeminiLiveManager({ apiKey: 'k', onControlCall, controlToolNames: SESSION_CONTROL_TOOL_NAMES });
+    const ws = new FakeWs();
+    mgr.activeWs = ws;
+    mgr.wireHandlers(ws, false);
+
+    ws.emit('message', JSON.stringify({
+      toolCall: { functionCalls: [
+        { id: 'c1', name: 'advance_phase', args: {} },
+        { id: 'c2', name: 'set_intent_mode', args: { mode: 'commit' } },
+      ] }
+    }));
+    await vi.waitFor(() => expect(ws.sent.length).toBe(2)); // BOTH calls answered despite the throw
+    expect(ws.sent[0].toolResponse.functionResponses[0].response.result).toMatch(/error/i);
     mgr.close();
   });
 

--- a/tests/unit/session-tools.test.mjs
+++ b/tests/unit/session-tools.test.mjs
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { SESSION_CONTROL_DECLARATIONS, SESSION_CONTROL_TOOL_NAMES } = require('../../poc/server/session-tools.js');
+const { PhaseTransitionHandler } = require('../../poc/server/phase-transition.js');
+const { GeminiLiveManager } = require('../../poc/server/gemini-live.js');
+
+describe('session control tool declarations', () => {
+  it('declares advance_phase and set_intent_mode with required params', () => {
+    const byName = Object.fromEntries(SESSION_CONTROL_DECLARATIONS.map((d) => [d.name, d]));
+    expect(byName.advance_phase.parameters.required).toEqual(['to_phase', 'confidence', 'carry_forward']);
+    expect(byName.set_intent_mode.parameters.required).toEqual(['mode']);
+    expect(SESSION_CONTROL_TOOL_NAMES.has('advance_phase')).toBe(true);
+    expect(SESSION_CONTROL_TOOL_NAMES.has('fetch_framework')).toBe(false);
+  });
+});
+
+describe('PhaseTransitionHandler.toolTransition (advance_phase)', () => {
+  let handler, onTransition;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onTransition = vi.fn();
+    handler = new PhaseTransitionHandler({ onTransition });
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('accepts a valid transition and passes the AI-written carry-forward', () => {
+    const result = handler.toolTransition(1, {
+      to_phase: 2, confidence: 8,
+      carry_forward: 'Root cause: fear of irrelevance. Constraint: 8 months runway.',
+      reason: 'Root cause identified and confirmed by user.',
+    });
+    expect(result.ok).toBe(true);
+    expect(onTransition).toHaveBeenCalledWith(1, 2, expect.objectContaining({
+      confidence: 8,
+      carryForward: 'Root cause: fear of irrelevance. Constraint: 8 months runway.',
+      source: 'tool',
+    }));
+  });
+
+  it('blocks forward transitions below the confidence threshold — feedback the AI hears', () => {
+    const result = handler.toolTransition(1, { to_phase: 2, confidence: 4, carry_forward: 'x' });
+    expect(result.ok).toBe(false);
+    expect(result.blocked).toBe(true);
+    expect(result.message).toMatch(/confidence 4 is below the required 6/);
+    expect(onTransition).not.toHaveBeenCalled();
+  });
+
+  it('allows going BACK to a phase regardless of confidence (revisiting is not gated)', () => {
+    const result = handler.toolTransition(4, { to_phase: 1, confidence: 2, carry_forward: 'need to re-mine' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('commit mode raises the gate to 8', () => {
+    handler.toolSetMode('commit');
+    expect(handler.toolTransition(0, { to_phase: 1, confidence: 7, carry_forward: 'x' }).blocked).toBe(true);
+    expect(handler.toolTransition(0, { to_phase: 1, confidence: 8, carry_forward: 'x' }).ok).toBe(true);
+  });
+
+  it('rejects missing/invalid confidence and invalid phases with instructive messages', () => {
+    expect(handler.toolTransition(0, { to_phase: 1, carry_forward: 'x' }).message).toMatch(/confidence.*required/);
+    expect(handler.toolTransition(0, { to_phase: 9, confidence: 9, carry_forward: 'x' }).ok).toBe(false);
+    expect(handler.toolTransition(2, { to_phase: 2, confidence: 9, carry_forward: 'x' }).message).toMatch(/Already in phase 2/);
+    expect(onTransition).not.toHaveBeenCalled();
+  });
+
+  it('debounces rapid successive transitions', () => {
+    expect(handler.toolTransition(0, { to_phase: 1, confidence: 9, carry_forward: 'a' }).ok).toBe(true);
+    expect(handler.toolTransition(1, { to_phase: 2, confidence: 9, carry_forward: 'b' }).blocked).toBe(true);
+    vi.advanceTimersByTime(6000);
+    expect(handler.toolTransition(1, { to_phase: 2, confidence: 9, carry_forward: 'b' }).ok).toBe(true);
+  });
+});
+
+describe('PhaseTransitionHandler.toolSetMode (set_intent_mode)', () => {
+  it('sets mode + threshold and notifies', () => {
+    const onModeDetected = vi.fn();
+    const handler = new PhaseTransitionHandler({ onModeDetected });
+    expect(handler.toolSetMode('Explore').ok).toBe(true);
+    expect(handler.intentMode).toBe('explore');
+    expect(handler.minConfidence).toBe(5);
+    expect(onModeDetected).toHaveBeenCalledWith('explore', 5);
+    expect(handler.toolSetMode('yolo').ok).toBe(false);
+  });
+});
+
+describe('GeminiLiveManager control-tool routing', () => {
+  class FakeWs extends EventEmitter {
+    constructor() { super(); this.readyState = 1; this.sent = []; }
+    send(m) { this.sent.push(JSON.parse(m)); }
+    close() { this.readyState = 3; this.emit('close', 1000, ''); }
+  }
+
+  it('routes control tools to onControlCall and replies with its message', async () => {
+    const onControlCall = vi.fn().mockReturnValue({ ok: true, message: 'Transition to phase 2 accepted.' });
+    const mgr = new GeminiLiveManager({
+      apiKey: 'k',
+      onControlCall,
+      controlToolNames: SESSION_CONTROL_TOOL_NAMES,
+    });
+    const ws = new FakeWs();
+    mgr.activeWs = ws;
+    mgr.wireHandlers(ws, false);
+
+    ws.emit('message', JSON.stringify({
+      toolCall: { functionCalls: [{ id: 'c1', name: 'advance_phase', args: { to_phase: 2, confidence: 9, carry_forward: 'done' } }] }
+    }));
+    await vi.waitFor(() => expect(ws.sent.length).toBeGreaterThan(0));
+
+    expect(onControlCall).toHaveBeenCalledWith({ name: 'advance_phase', args: { to_phase: 2, confidence: 9, carry_forward: 'done' } });
+    const resp = ws.sent[0].toolResponse.functionResponses[0];
+    expect(resp).toMatchObject({ id: 'c1', name: 'advance_phase', response: { result: 'Transition to phase 2 accepted.' } });
+    mgr.close();
+  });
+
+  it('does not send control tools to the framework fetcher', async () => {
+    const frameworkFetcher = { handleFunctionCall: vi.fn() };
+    const mgr = new GeminiLiveManager({
+      apiKey: 'k',
+      frameworkFetcher,
+      onControlCall: vi.fn().mockReturnValue({ message: 'ok' }),
+      controlToolNames: SESSION_CONTROL_TOOL_NAMES,
+    });
+    const ws = new FakeWs();
+    mgr.activeWs = ws;
+    mgr.wireHandlers(ws, false);
+
+    ws.emit('message', JSON.stringify({
+      toolCall: { functionCalls: [
+        { id: '1', name: 'set_intent_mode', args: { mode: 'commit' } },
+        { id: '2', name: 'fetch_framework', args: { framework: 'yc' } },
+      ] }
+    }));
+    await vi.waitFor(() => expect(mgr.onControlCall).toHaveBeenCalledTimes(1));
+
+    expect(frameworkFetcher.handleFunctionCall).toHaveBeenCalledTimes(1);
+    expect(frameworkFetcher.handleFunctionCall).toHaveBeenCalledWith({ name: 'fetch_framework', args: { framework: 'yc' } });
+    mgr.close();
+  });
+});

--- a/tests/unit/supabase-buffer.test.mjs
+++ b/tests/unit/supabase-buffer.test.mjs
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { SupabaseBuffer, PHASE_NAMES } = require('../../poc/server/supabase-buffer.js');
+
+/** Chainable fake for the supabase-js query builder. */
+function makeFakeSupabase(overrides = {}) {
+  const calls = [];
+  const result = { data: null, error: null, ...overrides };
+  const builder = new Proxy({}, {
+    get(_, prop) {
+      if (prop === 'then') {
+        // Awaiting the chain resolves to the canned result
+        return (resolve) => resolve(result);
+      }
+      return (...args) => {
+        calls.push([prop, ...args]);
+        return builder;
+      };
+    },
+  });
+  return {
+    client: { from: (table) => { calls.push(['from', table]); return builder; }, rpc: (...a) => { calls.push(['rpc', ...a]); return Promise.resolve(result); } },
+    calls,
+    result,
+  };
+}
+
+describe('SupabaseBuffer', () => {
+  it('throws without credentials', () => {
+    const saved = { url: process.env.SUPABASE_URL, key: process.env.SUPABASE_KEY };
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_KEY;
+    expect(() => new SupabaseBuffer()).toThrow(/required/);
+    if (saved.url) process.env.SUPABASE_URL = saved.url;
+    if (saved.key) process.env.SUPABASE_KEY = saved.key;
+  });
+
+  describe('with a mocked client', () => {
+    let buffer, fake;
+
+    beforeEach(() => {
+      buffer = new SupabaseBuffer({ supabaseUrl: 'https://test.supabase.co', supabaseKey: 'test-key' });
+      fake = makeFakeSupabase();
+      buffer.supabase = fake.client;
+    });
+
+    it('startSession stores the returned session id', async () => {
+      fake.result.data = { id: 'session-uuid-1' };
+      const id = await buffer.startSession('tok123');
+      expect(id).toBe('session-uuid-1');
+      expect(buffer.sessionId).toBe('session-uuid-1');
+      expect(fake.calls[0]).toEqual(['from', 'sessions']);
+      expect(fake.calls.some(([m]) => m === 'insert')).toBe(true);
+    });
+
+    it('startSession throws on error', async () => {
+      fake.result.error = { message: 'nope' };
+      await expect(buffer.startSession('tok')).rejects.toThrow(/startSession failed: nope/);
+    });
+
+    it('writeUtterance requires an active session', async () => {
+      await expect(buffer.writeUtterance(0, 'user', 'hi')).rejects.toThrow(/No active session/);
+    });
+
+    it('writeUtterance skips empty text without touching the DB', async () => {
+      buffer.sessionId = 'sid';
+      await buffer.writeUtterance(1, 'user', '   ');
+      expect(fake.calls).toHaveLength(0);
+    });
+
+    it('writeUtterance trims text and inserts', async () => {
+      buffer.sessionId = 'sid';
+      await buffer.writeUtterance(2, 'ai', '  an insight  ', true);
+      const insert = fake.calls.find(([m]) => m === 'insert');
+      expect(insert[1]).toMatchObject({ session_id: 'sid', phase: 2, speaker: 'ai', text: 'an insight', is_key_point: true });
+    });
+
+    it('markFlushed is a no-op for an empty id list', async () => {
+      await buffer.markFlushed([]);
+      await buffer.markFlushed(null);
+      expect(fake.calls).toHaveLength(0);
+    });
+
+    it('getUnflushedUtterances returns [] with no session', async () => {
+      expect(await buffer.getUnflushedUtterances()).toEqual([]);
+    });
+
+    it('endSession marks completed and clears the session id', async () => {
+      buffer.sessionId = 'sid';
+      await buffer.endSession();
+      expect(buffer.sessionId).toBeNull();
+      const update = fake.calls.find(([m]) => m === 'update');
+      expect(update[1]).toMatchObject({ status: 'completed' });
+    });
+
+    it('saveCarryForward upserts on session_id,phase', async () => {
+      buffer.sessionId = 'sid';
+      await buffer.saveCarryForward(1, 'Root cause found.', 8, 'squeeze notes', 'https://github.com/x/1');
+      const upsert = fake.calls.find(([m]) => m === 'upsert');
+      expect(upsert[1]).toMatchObject({ phase: 1, carry_forward: 'Root cause found.', confidence: 8 });
+      expect(upsert[2]).toMatchObject({ onConflict: 'session_id,phase' });
+    });
+  });
+
+  it('exports the 8 canonical phase names', () => {
+    expect(PHASE_NAMES).toHaveLength(8);
+    expect(PHASE_NAMES[1]).toBe('Mine');
+    expect(PHASE_NAMES[7]).toBe('Verify');
+  });
+});


### PR DESCRIPTION
Sprint tracker: #178 — all batches complete (1, 2, 3, logic upgrade Batch 5, and fresh-eyes fix pass Batch 6).

## Batch 1 — Fixes
- **#176**: `SESSION_NONCE_EXPIRY_MS` 60s → 300s so slow Railway cold-start responses can't expire the auth nonce mid-flow (one-time-use token, still safe)
- **#175**: new smoke harness `npm run smoke` (tests/smoke/smoke.mjs) — backend `/health`, WebSocket handshake, frontend load via headless Chromium with a fallback strictly limited to environment blocks. ⚠️ Found **#179: production backend is DOWN** (Railway 404 "Application not found")
- **#177**: verified RLS live (all 6 tables), fixed 4 `function_search_path_mutable` advisor warnings, closed the issue

## Batch 2 — Safety net
- **84 unit tests** (Vitest): session-state, phase-transition, context-manager, email-auth, supabase-buffer, hot-memory, gemini-live, session-tools
- **ESLint** flat config; fixed all 5 errors it found
- **GitHub Actions CI**: lint + tests + server-boot smoke (health-polled, no fixed sleep); production smoke warns while #179 is open

## Batch 3 — Modernization
- **#169 hot.md memory layer**: session summaries (≤5 bullets) written on stop AND disconnect, injected at session start only; works for short sessions; gitignored. Plus `poc/knowledge/index.md` master index
- **Gemini Live native session resumption**: `sessionResumption` + `contextWindowCompression` + `GoAway` early swap, layered on the 3-phase swap; kill switch `GEMINI_NATIVE_RESUMPTION=0`

## Batch 5 — Core logic: tool-based phase transitions
- `advance_phase(to_phase, confidence, carry_forward, reason)` and `set_intent_mode(mode)` replace regex-over-transcript + spoken tags as the control channel
- Confidence gate is a feedback loop: blocked transitions return "confidence 4 below required 6 — keep digging" as the tool response the AI hears
- All 8 prompts updated; regex kept as a hardened fallback

## Batch 6 — Adversarial fresh-eyes review: 10 confirmed findings, all fixed
- **Stale isStandby flag** silenced audio/barge-in/GoAway on promoted connections after the first 14-min swap (pre-existing) → live identity checks
- **Regex side door** around the confidence gate (negations, no gate, no suppression after block) → closed three ways
- GoAway standby lifecycle (orphan leak, premature swap before setup ack) → fixed
- Phase-change reconnects no longer resume the old phase's session state; handles only from the active connection
- Tool calls always answered (throws/rejections/closed sockets) — no model stalls
- `set_intent_mode` can't downgrade the threshold; thresholds single-sourced
- hot.md: disconnect writes, short-session bullets, gitignore
- Smoke fallback no longer masks real page failures; CI health-polls

## Verification
- `npm test` → 84/84 (exit 0) · `npm run lint` → 0 errors · server boots + smoke passes locally · CI green on head `c686893`
- Not provable yet: behavior against the real Gemini API (needs one live voice session — blocked on #179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRV9L9k1yMi7qwV26PxaWo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recent-session memory to help maintain relevant context across sessions.
  * Added native session resumption and smoother reconnection during live interactions.
  * Added structured controls for phase transitions and intent modes, including confidence checks and carry-forward summaries.
* **Bug Fixes**
  * Improved connection swapping to prevent interruptions from stale or incomplete connections.
  * Extended sign-in link validity to five minutes to better support slow responses.
  * Improved timeout and configuration error reporting.
* **Tests**
  * Added automated unit, smoke, lint, and deployment health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->