### PR TITLE
UX from first live session: full transcript, live text injection, spoken transitions, warmer intro

### DIFF
--- a/poc/prompts/phase-0-user-stories.txt
+++ b/poc/prompts/phase-0-user-stories.txt
@@ -5,7 +5,7 @@ CORE IDENTITY:
 - You are a co-founder, not an interviewer. Listen first, then contribute.
 - Stoicism is your backbone: What's in their control? Worst case?
 - Keep responses to 2-3 sentences. Like a sharp friend.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 TOOLS — USE THEM ACTIVELY:
@@ -46,8 +46,9 @@ CONTEXT DOCUMENTS: If you have been given context about the user's project (GitH
 5. Do NOT ask the user to explain what's already in the documents.
 
 HOW TO OPEN:
-- If you HAVE project context: "I've read through your [repo/documents]. Here's what I see — [brief summary]. Now let me understand what YOU want from this. Based on what I've read, it looks like the core challenge is [X]. Is that right, or is there something deeper?"
-- If you have NO context: "Welcome to The Thinking Foundry. I'm going to lead you through 8 phases of structured thinking — from understanding your problem to a concrete plan. The whole thing usually takes under 15 minutes. Let's start — what's the problem you're wrestling with? Be specific."
+Set the frame first — one or two sentences so they know what they've walked into — THEN ask your first question. Don't over-explain; warm and clear, not a lecture.
+- If you HAVE project context: "I've read through your [repo/documents], so I've got the background. Here's how this works: I'm going to lead you through eight short phases — we'll pin down what you actually want, dig for the real problem underneath it, explore options, pressure-test them, and land on a concrete plan. I'll ask a lot of questions and push back where it's useful — that's the point. Based on what I've read, it looks like the core challenge is [X]. Is that right, or is there something deeper?"
+- If you have NO context: "Welcome to The Thinking Foundry. Here's how this works: I'm going to lead you through eight short phases — from understanding what you really want, to digging out the root problem, exploring options, stress-testing them, and finishing with a concrete plan and a first step. I'll ask a lot of questions and challenge your thinking as we go — that's how we get to clarity, usually in under an hour. So let's start at the beginning: what's the problem you're wrestling with? Be specific."
 
 DETECT INTENT MODE (do this early, within first 2-3 exchanges):
 Listen for signals about what they want from this session:

--- a/poc/prompts/phase-1-mine.txt
+++ b/poc/prompts/phase-1-mine.txt
@@ -9,7 +9,7 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY

--- a/poc/prompts/phase-2-scout.txt
+++ b/poc/prompts/phase-2-scout.txt
@@ -9,7 +9,7 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY

--- a/poc/prompts/phase-3-assay.txt
+++ b/poc/prompts/phase-3-assay.txt
@@ -9,7 +9,7 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY

--- a/poc/prompts/phase-4-crucible.txt
+++ b/poc/prompts/phase-4-crucible.txt
@@ -9,7 +9,7 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY

--- a/poc/prompts/phase-5-auditor.txt
+++ b/poc/prompts/phase-5-auditor.txt
@@ -9,7 +9,7 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY

--- a/poc/prompts/phase-6-plan.txt
+++ b/poc/prompts/phase-6-plan.txt
@@ -9,7 +9,7 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY

--- a/poc/prompts/phase-7-verify.txt
+++ b/poc/prompts/phase-7-verify.txt
@@ -9,7 +9,7 @@ RULES:
 - Resist premature closure. Push one more round.
 - Call fetch_framework(name) when you need framework depth.
 - Pause is normal. Pick up naturally when they resume.
-- You decide phase transitions. When this phase is done, call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward: a 3-5 sentence summary of findings for the next phase. Silent tool call — never announce it or read it aloud.
+- You decide phase transitions. When this phase is done, FIRST say ONE short sentence out loud that marks the shift and names what's next (e.g. "Good — I've got what I need on the goal. Now let's dig into why this is really happening."). THEN call the advance_phase tool with to_phase, your honest confidence (1-10), and a carry_forward (3-5 sentence summary for the next phase). Never read the tool call or its fields aloud — just say the human sentence, naturally.
 - If advance_phase responds "blocked", your confidence is below the bar. Say what would raise it, work on that, then retry.
 
 PHASES: User Stories → MINE → SCOUT → ASSAY → CRUCIBLE → AUDITOR → PLAN → VERIFY

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -13,12 +13,9 @@ const { GitHubConnector } = require('../context/github-connector');
 const { SupabaseBuffer } = require('./supabase-buffer');
 const { GitHubPersistence } = require('./github-persistence');
 
-// ── Condensation thresholds (bullet point generation) ──
+// ── Transcript thresholds (minimum lengths to bother emitting a line) ──
 const MIN_AI_TEXT_LENGTH = 30;
-const MIN_BULLET_COMBINE_LENGTH = 40;
-const MAX_BULLET_LENGTH = 80;
 const MIN_USER_TEXT_LENGTH = 10;
-const MIN_USER_BULLET_COMBINE = 30;
 const SUBSTANTIAL_BUFFER_THRESHOLD = 50;
 const MAX_CONTEXT_INJECTION_LENGTH = 10000;
 const { PhaseTransitionHandler } = require('./phase-transition');
@@ -275,33 +272,21 @@ wss.on('connection', (clientWs, req) => {
     aiTurnBuffer = '';
     if (text.length < MIN_AI_TEXT_LENGTH) return;
 
-    // Strip internal signals before creating bullet
+    // Strip internal signals, then send the FULL utterance — no first-sentence-only,
+    // no character cap. The transcript shows everything and the client wraps long lines.
     const cleaned = text
       .replace(/\[MODE:\w+\]/gi, '')
       .replace(/\[PHASE_COMPLETE\]/gi, '')
       .replace(/\[SYSTEM\][^\n]*/gi, '')
+      .replace(/\s+/g, ' ')
       .trim();
     if (cleaned.length < MIN_AI_TEXT_LENGTH) return;
 
-    // Take FIRST sentence — prompts enforce insight-first, question-last
-    const sentences = cleaned.split(/(?<=[.!?])\s+/).filter(s => s.trim().length > 0);
-    let bullet = sentences[0] || cleaned;
+    sendToClient('outline_item', { speaker: 'ai', text: cleaned, phase: session.currentPhase });
 
-    // If first sentence is very short, concatenate first two
-    if (bullet.length < MIN_BULLET_COMBINE_LENGTH && sentences.length > 1) {
-      bullet = sentences[0] + ' ' + sentences[1];
-    }
-
-    // Cap at ~80 chars
-    if (bullet.length > MAX_BULLET_LENGTH) {
-      bullet = bullet.substring(0, MAX_BULLET_LENGTH - 3) + '...';
-    }
-
-    sendToClient('outline_item', { speaker: 'ai', text: bullet, phase: session.currentPhase });
-
-    // Persist as key point
+    // Persist the full text
     if (supabaseBuffer) {
-      supabaseBuffer.writeUtterance(session.currentPhase, 'ai', bullet, true)
+      supabaseBuffer.writeUtterance(session.currentPhase, 'ai', cleaned, true)
         .catch(err => console.error('[OUTLINE] Supabase write error:', err.message));
     }
   }
@@ -325,15 +310,12 @@ wss.on('connection', (clientWs, req) => {
     userTurnBuffer = '';
     if (text.length < MIN_USER_TEXT_LENGTH) return;
 
-    const sentences = text.split(/(?<=[.!?])\s+/).filter(s => s.trim().length > 0);
-    let bullet = sentences[0] || text;
-    if (bullet.length < MIN_USER_BULLET_COMBINE && sentences.length > 1) bullet = sentences[0] + ' ' + sentences[1];
-    if (bullet.length > MAX_BULLET_LENGTH) bullet = bullet.substring(0, MAX_BULLET_LENGTH - 3) + '...';
-
-    sendToClient('outline_item', { speaker: 'user', text: bullet, phase: session.currentPhase });
+    // Full user utterance — no first-sentence-only, no cap. Client wraps.
+    const cleaned = text.replace(/\s+/g, ' ').trim();
+    sendToClient('outline_item', { speaker: 'user', text: cleaned, phase: session.currentPhase });
 
     if (supabaseBuffer) {
-      supabaseBuffer.writeUtterance(session.currentPhase, 'user', bullet, true)
+      supabaseBuffer.writeUtterance(session.currentPhase, 'user', cleaned, true)
         .catch(function(err) { console.error('[OUTLINE] Supabase write error:', err.message); });
     }
   };
@@ -908,37 +890,61 @@ wss.on('connection', (clientWs, req) => {
         }
         break;
 
-      case 'add-context':
-        // Mid-session text/document context — store for next Gemini reconnection
-        // NOTE: Cannot inject text directly into AUDIO-only Gemini Live sessions
-        // (causes error 1007). Instead, add to context manager so it's included
-        // in the next phase transition or reconnection's system prompt.
-        if (Array.isArray(msg.documents) && msg.documents.length > 0) {
-          const contextParts = msg.documents
-            .filter(d => d && d.content)
-            .map(d => `[User shared: ${d.name || 'document'}]\n${d.content}`)
-            .join('\n\n');
-          const truncated = contextParts.length > MAX_CONTEXT_INJECTION_LENGTH
-            ? contextParts.substring(0, 9997) + '...'
-            : contextParts;
+      case 'add-context': {
+        // Mid-session text/document — inject it into the LIVE session so the AI
+        // reads it NOW. AUDIO-only Gemini Live rejects raw text turns (error 1007),
+        // so we fold the document into the system prompt and do a fast reconnect
+        // (same ~1s blip as a phase change) with a directive to acknowledge it.
+        if (!Array.isArray(msg.documents) || msg.documents.length === 0) break;
 
-          // Add to context manager (picked up on next reconnect/phase change)
-          context.addUtterance('user', truncated);
-          console.log(`[WS] Stored mid-session context: ${msg.documents.length} doc(s), ${truncated.length} chars (applied on next reconnect)`);
+        const contextParts = msg.documents
+          .filter(d => d && d.content)
+          .map(d => `[User shared: ${d.name || 'document'}]\n${d.content}`)
+          .join('\n\n');
+        if (!contextParts.trim()) break;
 
-          // Persist to Supabase
-          if (supabaseBuffer) {
-            supabaseBuffer.writeUtterance(session.currentPhase, 'user', truncated)
-              .catch(err => console.error('[SUPABASE] Context write error:', err.message));
+        const clipped = contextParts.length > MAX_CONTEXT_INJECTION_LENGTH
+          ? contextParts.substring(0, MAX_CONTEXT_INJECTION_LENGTH - 3) + '...'
+          : contextParts;
+
+        // Accumulate into the session's document context + transcript + Supabase
+        sessionDocContext = sessionDocContext ? `${sessionDocContext}\n\n${clipped}` : clipped;
+        context.addUtterance('user', clipped);
+        if (supabaseBuffer) {
+          supabaseBuffer.writeUtterance(session.currentPhase, 'user', clipped)
+            .catch(err => console.error('[SUPABASE] Context write error:', err.message));
+        }
+
+        sendToClient('outline_item', {
+          speaker: 'system',
+          text: 'Reading what you shared…',
+          phase: session.currentPhase,
+        });
+
+        if (gemini) {
+          try {
+            let phaseKnowledge = await knowledgeLoader.load({
+              phase: session.currentPhase,
+              frameworks: sessionFrameworks.length > 0 ? sessionFrameworks : undefined,
+              fullContent: false,
+              githubContext: sessionGithubContext || undefined,
+              driveContext: sessionDocContext || undefined,
+              includeHotMemory: false,
+            });
+            // Front-load the just-shared document with an explicit read-it-now directive
+            phaseKnowledge = `--- THE USER JUST SHARED THIS WITH YOU, MID-SESSION ---\n${clipped}\n--- END ---\n` +
+              `Open your very next response by briefly acknowledging what they shared (one sentence), then weave it into the conversation.\n\n` +
+              phaseKnowledge;
+            gemini.knowledgeContext = phaseKnowledge;
+            await gemini.forceReconnect(session.currentPhase, context.getCondensedContext());
+            console.log(`[WS] Injected mid-session context live: ${msg.documents.length} doc(s), ${clipped.length} chars`);
+          } catch (err) {
+            console.error('[WS] Live context injection failed:', err.message);
+            sendToClient('error', { message: 'Could not read that just now — it will be included as we continue.' });
           }
-
-          sendToClient('outline_item', {
-            speaker: 'system',
-            text: 'Context saved. It will be included at the next phase transition.',
-            phase: session.currentPhase
-          });
         }
         break;
+      }
 
       case 'generate_crucible':
         // Article 19: Offered, Not Forced. User chose to generate.


### PR DESCRIPTION
Four fixes from Roderic's first live voice session (2026-07-14). All server/prompt-side, so they apply to every UI.

1. **Transcript no longer truncates.** The server was showing only the first sentence of each turn, capped at 80 chars + "…". Now it sends the full utterance and the client wraps long lines. (`flushAiTurnBuffer` / `flushUserTurnBuffer` in index.js; removed dead cap constants.)
2. **Shared text is read live.** `add-context` previously queued text for "the next phase transition" — so the AI said *"I can't read that."* Now it folds the document into the system prompt and does a fast reconnect (same ~1s blip as a phase change) with a directive to acknowledge it immediately.
3. **Phase transitions are announced.** All 8 prompts now tell the AI to say one human sentence marking the shift *before* the silent `advance_phase` call — so Phase 0→1 no longer feels like a silent jump (this was the "why did it move when I clicked Drive?" confusion — the move was correct, just unspoken).
4. **Warmer Phase-0 opening.** Sets the frame — eight phases, what each does, "I'll challenge you, that's the point" — in 1-2 sentences before the first question, instead of "let's go."

## Verification
- `npm test` → 84/84 · `npm run lint` → 0 errors · server boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRV9L9k1yMi7qwV26PxaWo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRV9L9k1yMi7qwV26PxaWo)_