### PR TITLE
fix: phase transitions detected on complete turn (not streaming fragments)

### DIFF
--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -284,6 +284,16 @@ wss.on('connection', (clientWs, req) => {
 
     sendToClient('outline_item', { speaker: 'ai', text: cleaned, phase: session.currentPhase });
 
+    // Phase-transition detection on the COMPLETE turn (not per streaming
+    // fragment) so multi-word signals like "let's move to Phase 1" are matched
+    // whole. onTransition handles persistence + reconnection.
+    if (phaseHandler) {
+      const result = phaseHandler.processAiUtterance(cleaned, session.currentPhase);
+      if (result?.blocked) {
+        sendToClient('phase_blocked', { reason: result.reason, confidence: result.confidence });
+      }
+    }
+
     // Persist the full text
     if (supabaseBuffer) {
       supabaseBuffer.writeUtterance(session.currentPhase, 'ai', cleaned, true)
@@ -505,14 +515,10 @@ wss.on('connection', (clientWs, req) => {
           }
         }
 
-        // Check AI responses for phase transition signals (Article 10)
-        if (role === 'model' && phaseHandler) {
-          const result = phaseHandler.processAiUtterance(text, session.currentPhase);
-          if (result?.blocked) {
-            sendToClient('phase_blocked', { reason: result.reason, confidence: result.confidence });
-          }
-          // If transition detected, onTransition callback handles everything
-        }
+        // NOTE: phase-transition detection runs on the COMPLETE turn in
+        // flushAiTurnBuffer — not here per-fragment. Streaming fragments split
+        // phrases like "let's move to Phase 1" across the detector's small
+        // window and get missed; the full turn is always matched whole.
       },
 
       onAudio: (audioBase64) => {


### PR DESCRIPTION
From the second live session: the AI announced "let's move to Phase 1 — MINE" but the UI stayed on Phase 0.

**Root cause:** transition detection ran on each streaming transcript *fragment* with only a 5-fragment memory window. Multi-word signals like "let's move to Phase 1" split across fragments and the start scrolled out of the window before the phase number arrived — so the regex never matched the whole phrase, and the `advance_phase` tool call didn't fire that turn either. It worked previous sessions by luck of fragment boundaries.

**Fix:** detection now runs once on the full assembled turn in `flushAiTurnBuffer`, so the whole signal is always matched.

Verified: `npm test` 84/84, lint clean.

This is a small stopgap — the larger canvas/streaming redesign we're discussing will likely rework this whole surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRV9L9k1yMi7qwV26PxaWo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRV9L9k1yMi7qwV26PxaWo)_