### PR TITLE
fix(add-context): guarantee live injection lands + stop stale directive leaking

### DIFF
--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -69,6 +69,11 @@ class GeminiLiveManager {
       : process.env.GEMINI_NATIVE_RESUMPTION !== '0';
     this.resumptionHandle = null;
     this.standbySetupComplete = false;
+
+    // One-shot prompt block (e.g. "the user just shared this, acknowledge it").
+    // Set via forceReconnect opts, rides exactly ONE setup, then cleared — it
+    // must never leak into the scheduled 13:30 standby setup 14 minutes later.
+    this.oneShotContext = null;
   }
 
   /**
@@ -88,6 +93,11 @@ class GeminiLiveManager {
     if (this.knowledgeContext) {
       prompt = `${this.knowledgeContext}\n\n--- PHASE INSTRUCTIONS ---\n${prompt}`;
       console.log(`[GEMINI] Injected ${this.knowledgeContext.length} chars of knowledge context`);
+    }
+
+    // Front-load any one-shot directive (mid-session context injection)
+    if (this.oneShotContext) {
+      prompt = `${this.oneShotContext}\n\n${prompt}`;
     }
 
     if (contextSummary) {
@@ -538,7 +548,7 @@ class GeminiLiveManager {
   /**
    * Force an immediate reconnection (e.g., phase change)
    */
-  async forceReconnect(phase, contextSummary) {
+  async forceReconnect(phase, contextSummary, opts = {}) {
     console.log(`[GEMINI] Force reconnect: phase=${phase}`);
     this.clearReconnectTimers();
 
@@ -546,8 +556,16 @@ class GeminiLiveManager {
     // Resuming the old phase's server-side session would carry its state into
     // the new phase, fighting the new prompt — drop the handle. Same-phase
     // reconnects (swap-failure fallback) keep it: same conversation.
-    if (phase !== this.phase) {
+    // Callers that change the prompt WITHOUT changing phase (live context
+    // injection) pass dropResumptionHandle: true — a resumed session may
+    // ignore the new systemInstruction, so continuity must come from the
+    // condensed context instead, exactly as on a phase change.
+    if (phase !== this.phase || opts.dropResumptionHandle) {
       this.resumptionHandle = null;
+    }
+
+    if (opts.oneShotContext !== undefined) {
+      this.oneShotContext = opts.oneShotContext;
     }
 
     this.phase = phase;
@@ -593,6 +611,11 @@ class GeminiLiveManager {
         resolve();
       });
     });
+
+    // One-shot consumed: it rode this reconnect's setup (sent in the open
+    // handler above, before resolve). Clear it so no later setup —
+    // scheduled standby, GoAway swap, next phase — repeats the directive.
+    this.oneShotContext = null;
   }
 
   /**

--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -71,8 +71,10 @@ class GeminiLiveManager {
     this.standbySetupComplete = false;
 
     // One-shot prompt block (e.g. "the user just shared this, acknowledge it").
-    // Set via forceReconnect opts, rides exactly ONE setup, then cleared — it
-    // must never leak into the scheduled 13:30 standby setup 14 minutes later.
+    // Set via forceReconnect opts, consumed by the FIRST setup that actually
+    // goes out (cleared in sendSetup at delivery) — a reconnect that errors
+    // before 'open' keeps it pending for the next setup, and it never leaks
+    // into the scheduled 13:30 standby setup 14 minutes later.
     this.oneShotContext = null;
   }
 
@@ -136,6 +138,10 @@ class GeminiLiveManager {
    */
   sendSetup(ws, phase, contextSummary) {
     const systemPrompt = this.getSystemPrompt(phase, contextSummary);
+    // Consume the one-shot at delivery: this setup carries it, no later one
+    // does. Clearing here (not at the end of forceReconnect) means a failed
+    // reconnect leaves it pending instead of silently discarding it.
+    this.oneShotContext = null;
 
     const setupMessage = {
       setup: {
@@ -611,11 +617,6 @@ class GeminiLiveManager {
         resolve();
       });
     });
-
-    // One-shot consumed: it rode this reconnect's setup (sent in the open
-    // handler above, before resolve). Clear it so no later setup —
-    // scheduled standby, GoAway swap, next phase — repeats the directive.
-    this.oneShotContext = null;
   }
 
   /**

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -942,7 +942,14 @@ wss.on('connection', (clientWs, req) => {
             // only this reconnect, so a scheduled swap 14 minutes later doesn't
             // re-instruct the AI to acknowledge an old share.
             gemini.knowledgeContext = phaseKnowledge;
-            const oneShot = `--- THE USER JUST SHARED THIS WITH YOU, MID-SESSION ---\n${clipped}\n--- END ---\n` +
+            // Reference the doc by name, don't re-embed it — the full text is
+            // already in the GOOGLE DRIVE CONTEXT section via driveContext
+            // (under "[User shared: <name>]"), so embedding `clipped` here
+            // would send the same body twice in one setup.
+            const docNames = msg.documents.filter(d => d && d.content)
+              .map(d => d.name || 'document').join(', ');
+            const oneShot = `--- THE USER JUST SHARED NEW MATERIAL WITH YOU, MID-SESSION: ${docNames} ---\n` +
+              `Its full text is in the GOOGLE DRIVE CONTEXT section of your context, under "[User shared: ...]".\n` +
               `Open your very next response by briefly acknowledging what they shared (one sentence), then weave it into the conversation.`;
             // Same-phase reconnect would normally KEEP the resumption handle,
             // and a resumed server-side session may ignore the changed

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -937,12 +937,21 @@ wss.on('connection', (clientWs, req) => {
               driveContext: sessionDocContext || undefined,
               includeHotMemory: false,
             });
-            // Front-load the just-shared document with an explicit read-it-now directive
-            phaseKnowledge = `--- THE USER JUST SHARED THIS WITH YOU, MID-SESSION ---\n${clipped}\n--- END ---\n` +
-              `Open your very next response by briefly acknowledging what they shared (one sentence), then weave it into the conversation.\n\n` +
-              phaseKnowledge;
+            // Durable prompt: the doc itself is already in phaseKnowledge via
+            // driveContext. The read-it-NOW directive is one-shot — it rides
+            // only this reconnect, so a scheduled swap 14 minutes later doesn't
+            // re-instruct the AI to acknowledge an old share.
             gemini.knowledgeContext = phaseKnowledge;
-            await gemini.forceReconnect(session.currentPhase, context.getCondensedContext());
+            const oneShot = `--- THE USER JUST SHARED THIS WITH YOU, MID-SESSION ---\n${clipped}\n--- END ---\n` +
+              `Open your very next response by briefly acknowledging what they shared (one sentence), then weave it into the conversation.`;
+            // Same-phase reconnect would normally KEEP the resumption handle,
+            // and a resumed server-side session may ignore the changed
+            // systemInstruction (the whole point of this injection). Force a
+            // fresh session — continuity comes from the condensed context.
+            await gemini.forceReconnect(session.currentPhase, context.getCondensedContext(), {
+              dropResumptionHandle: true,
+              oneShotContext: oneShot,
+            });
             console.log(`[WS] Injected mid-session context live: ${msg.documents.length} doc(s), ${clipped.length} chars`);
           } catch (err) {
             console.error('[WS] Live context injection failed:', err.message);

--- a/tests/unit/gemini-live.test.mjs
+++ b/tests/unit/gemini-live.test.mjs
@@ -197,6 +197,43 @@ describe('GeminiLiveManager — native session resumption', () => {
     expect(mgr.resumptionHandle).toBe('h-same');
   });
 
+  it('forceReconnect can drop the handle on a SAME-phase reconnect (live context injection)', async () => {
+    // add-context reconnects at the same phase but with a changed system prompt.
+    // A resumed server-side session may ignore the new systemInstruction, so the
+    // caller must be able to force a fresh session — continuity via condensed context.
+    mgr.resumptionHandle = 'h-stale';
+    mgr.phase = 2;
+    const fresh = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => fresh.emit('open'), 0); return fresh; };
+
+    const p = mgr.forceReconnect(2, 'ctx', { dropResumptionHandle: true });
+    await vi.advanceTimersByTimeAsync(10);
+    await p;
+
+    expect(mgr.resumptionHandle).toBeNull();
+    // The setup actually sent must NOT carry the stale handle either
+    expect(lastSetup(fresh).sessionResumption).toEqual({});
+  });
+
+  it('one-shot context rides exactly one reconnect and never leaks into later setups', async () => {
+    mgr.phase = 2;
+    const fresh = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => fresh.emit('open'), 0); return fresh; };
+
+    const p = mgr.forceReconnect(2, 'ctx', { oneShotContext: 'ACKNOWLEDGE THE SHARED DOC NOW' });
+    await vi.advanceTimersByTimeAsync(10);
+    await p;
+
+    // Present in the setup for THIS reconnect…
+    expect(lastSetup(fresh).systemInstruction.parts[0].text).toContain('ACKNOWLEDGE THE SHARED DOC NOW');
+
+    // …absent from every later setup (e.g. the scheduled 13:30 standby),
+    // so the AI isn't re-told to acknowledge a doc shared 14 minutes ago.
+    const later = new FakeWs();
+    mgr.sendSetup(later, 2, 'ctx');
+    expect(lastSetup(later).systemInstruction.parts[0].text).not.toContain('ACKNOWLEDGE THE SHARED DOC NOW');
+  });
+
   it('close() during a GoAway swap does not throw or fire callbacks', () => {
     const active = new FakeWs();
     mgr.activeWs = active;

--- a/tests/unit/gemini-live.test.mjs
+++ b/tests/unit/gemini-live.test.mjs
@@ -234,6 +234,29 @@ describe('GeminiLiveManager — native session resumption', () => {
     expect(lastSetup(later).systemInstruction.parts[0].text).not.toContain('ACKNOWLEDGE THE SHARED DOC NOW');
   });
 
+  it('one-shot survives a FAILED reconnect and rides the next successful setup exactly once', async () => {
+    // If the fresh socket errors before 'open', no setup was sent — the
+    // directive must stay pending (not be silently discarded) and then ride
+    // the next setup that actually goes out, once.
+    mgr.phase = 2;
+    const failing = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => failing.emit('error', new Error('boom')), 0); return failing; };
+
+    const p = mgr.forceReconnect(2, 'ctx', { oneShotContext: 'ACK THE DOC' });
+    await vi.advanceTimersByTimeAsync(10);
+    await p;
+
+    expect(mgr.oneShotContext).toBe('ACK THE DOC'); // still pending — never delivered
+
+    const next = new FakeWs();
+    mgr.sendSetup(next, 2, 'ctx');
+    expect(lastSetup(next).systemInstruction.parts[0].text).toContain('ACK THE DOC');
+
+    const after = new FakeWs();
+    mgr.sendSetup(after, 2, 'ctx');
+    expect(lastSetup(after).systemInstruction.parts[0].text).not.toContain('ACK THE DOC');
+  });
+
   it('close() during a GoAway swap does not throw or fire callbacks', () => {
     const active = new FakeWs();
     mgr.activeWs = active;


### PR DESCRIPTION
## What

Two real bugs in the #181 live-injection feature, found by the adversarial handoff review (#185), plus two hardening fixes from the pre-merge /code-review pass.

### Bug 1 — the shared doc could never reach the model
`add-context` reconnects at the SAME phase, so `forceReconnect` kept the native resumption handle — and a resumed server-side session may ignore the changed `systemInstruction` (the entire point of the injection). Now the caller passes `dropResumptionHandle: true`; continuity comes from the condensed context, exactly as on a phase change.

### Bug 2 — stale "acknowledge this NOW" directive leaked into every later swap
The transient directive was persisted into `knowledgeContext`, so the scheduled 13:30 standby setup ~14 minutes later re-instructed the AI to greet an old share. Now a one-shot: consumed in `sendSetup` at actual delivery, rides exactly one setup.

### Review hardening (pre-merge /code-review, 2 confirmed findings fixed)
- One-shot survives a reconnect that errors before `open` (was silently discarded) — pending until the next successful setup.
- Doc referenced by NAME in the one-shot; full text lives only in the GOOGLE DRIVE CONTEXT section (was embedded twice, ~20KB for a max-size doc).

### Documented trade-offs (not changed)
- Dropping the handle costs server-side history → lossy condensed-context continuity. Accepted: same trade as every phase change; the alternative risks the doc never landing.
- `forceReconnect` re-entrancy race is pre-existing on main — tracked as a separate task.

## Tests
3 new regression tests (fail-before/pass-after), suite **87/87**, lint 0 errors.

Root cause of both bugs: transient intent mutating durable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)