### PR TITLE
fix(gemini-live): serialize forceReconnect — overlapping calls leaked connections

### DIFF
--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -76,6 +76,9 @@ class GeminiLiveManager {
     // before 'open' keeps it pending for the next setup, and it never leaks
     // into the scheduled 13:30 standby setup 14 minutes later.
     this.oneShotContext = null;
+
+    // Serializes forceReconnect calls — see forceReconnect for why.
+    this._reconnectQueue = Promise.resolve();
   }
 
   /**
@@ -553,8 +556,31 @@ class GeminiLiveManager {
 
   /**
    * Force an immediate reconnection (e.g., phase change)
+   *
+   * Serialized: the client WS message handler in index.js is async and the
+   * EventEmitter doesn't await it, so two rapid messages (add-context racing
+   * a phase transition, two shares back-to-back) can call this concurrently.
+   * Unserialized, each call captured a different oldWs, both dialed sockets,
+   * the loser's connection leaked open with handlers wired, and
+   * reconnectionCount double-incremented. Chaining on _reconnectQueue runs
+   * each reconnect against the settled state of the previous one; the latest
+   * requested phase/contextSummary wins because it runs last, and a queued
+   * oneShotContext is stored inside its own step, so it rides the FINAL
+   * surviving connection's setup (sendSetup consumes it exactly once).
    */
-  async forceReconnect(phase, contextSummary, opts = {}) {
+  forceReconnect(phase, contextSummary, opts = {}) {
+    const run = this._reconnectQueue.then(() => this._doForceReconnect(phase, contextSummary, opts));
+    // The caller sees its own reconnect's outcome, but a failed step must
+    // never poison the chain for later reconnects.
+    this._reconnectQueue = run.catch((err) => {
+      console.error('[GEMINI] forceReconnect step failed:', err.message);
+    });
+    return run;
+  }
+
+  async _doForceReconnect(phase, contextSummary, opts = {}) {
+    // A reconnect dequeued after close() must not dial out — session is over.
+    if (this.closed) return;
     console.log(`[GEMINI] Force reconnect: phase=${phase}`);
     this.clearReconnectTimers();
 
@@ -591,10 +617,15 @@ class GeminiLiveManager {
       this.activeWs = this.createConnection();
       this.wireHandlers(this.activeWs, false);
 
-      this.activeWs.on('open', () => {
+      const ws = this.activeWs;
+      ws.on('open', () => {
+        // close() may have run while this socket was dialing — activeWs is
+        // null then, and setting up / re-arming timers would resurrect a
+        // dead session.
+        if (this.closed) { resolve(); return; }
         this.connectionStartTime = Date.now();
         this.reconnectionCount++;
-        this.sendSetup(this.activeWs, phase, contextSummary);
+        this.sendSetup(ws, phase, contextSummary);
         this.scheduleReconnection();
 
         // Close old — clear isSwapping when it actually closes

--- a/tests/unit/gemini-live.test.mjs
+++ b/tests/unit/gemini-live.test.mjs
@@ -269,3 +269,121 @@ describe('GeminiLiveManager — native session resumption', () => {
     expect(() => vi.advanceTimersByTime(10000)).not.toThrow();
   });
 });
+
+describe('GeminiLiveManager — forceReconnect serialization', () => {
+  let mgr;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mgr = new GeminiLiveManager({ apiKey: 'test-key' });
+  });
+  afterEach(() => {
+    mgr.close();
+    vi.useRealTimers();
+  });
+
+  // Each dial returns a fresh FakeWs that emits 'open' a few ms later —
+  // long enough for a second forceReconnect to arrive while the first is
+  // still in flight, which is exactly the race being tested.
+  const trackDials = (created, openAfterMs = 5) => () => {
+    const f = new FakeWs();
+    created.push(f);
+    setTimeout(() => f.emit('open'), openAfterMs);
+    return f;
+  };
+
+  it('overlapping reconnects are serialized — one surviving connection, one timer set, no double counting', async () => {
+    const created = [];
+    mgr.createConnection = trackDials(created);
+    const initial = new FakeWs();
+    mgr.activeWs = initial;
+    mgr.connectionStartTime = Date.now();
+    mgr.phase = 1;
+
+    // A phase transition and an add-context share fire back-to-back — the
+    // second call arrives while the first reconnect is still dialing.
+    const p1 = mgr.forceReconnect(2, 'ctx-transition');
+    const p2 = mgr.forceReconnect(2, 'ctx-share', { dropResumptionHandle: true, oneShotContext: 'ACK THE DOC' });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await Promise.all([p1, p2]);
+
+    expect(created).toHaveLength(2);              // second dial waited for the first to complete
+    expect(mgr.activeWs).toBe(created[1]);        // latest request wins
+    expect(initial.readyState).toBe(3);           // every predecessor closed —
+    expect(created[0].readyState).toBe(3);        // nothing leaked open
+    expect(mgr.reconnectionCount).toBe(2);        // +1 per COMPLETED reconnect, no double-increment
+    expect(mgr.reconnectTimers).toHaveLength(3);  // exactly one armed prepare/setup/swap set
+    expect(mgr.contextSummary).toBe('ctx-share');
+
+    // The one-shot rides the FINAL surviving connection's setup, exactly once
+    const carries = (ws) => ws.sent.filter((m) => m.setup?.systemInstruction.parts[0].text.includes('ACK THE DOC'));
+    expect(carries(created[0])).toHaveLength(0);
+    expect(carries(created[1])).toHaveLength(1);
+    expect(mgr.oneShotContext).toBeNull();
+  });
+
+  it('three rapid reconnects settle on the last requested phase and context', async () => {
+    const created = [];
+    mgr.createConnection = trackDials(created);
+    mgr.activeWs = new FakeWs();
+    mgr.connectionStartTime = Date.now();
+    mgr.phase = 0;
+
+    const all = Promise.all([
+      mgr.forceReconnect(1, 'a'),
+      mgr.forceReconnect(2, 'b'),
+      mgr.forceReconnect(3, 'c'),
+    ]);
+    await vi.advanceTimersByTimeAsync(100);
+    await all;
+
+    expect(created).toHaveLength(3);
+    expect(mgr.activeWs).toBe(created[2]);
+    expect(mgr.phase).toBe(3);
+    expect(mgr.contextSummary).toBe('c');
+    expect(mgr.reconnectionCount).toBe(3);
+    expect(created[0].readyState).toBe(3);
+    expect(created[1].readyState).toBe(3);
+  });
+
+  it('a reconnect whose socket errors before open does not block later reconnects (queue not poisoned)', async () => {
+    mgr.activeWs = new FakeWs();
+    mgr.connectionStartTime = Date.now();
+    mgr.phase = 1;
+
+    const failing = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => failing.emit('error', new Error('boom')), 0); return failing; };
+    const p1 = mgr.forceReconnect(2, 'ctx', { oneShotContext: 'ACK' });
+    await vi.advanceTimersByTimeAsync(10);
+    await p1;
+    expect(mgr.oneShotContext).toBe('ACK'); // never delivered — still pending
+
+    const fresh = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => fresh.emit('open'), 0); return fresh; };
+    const p2 = mgr.forceReconnect(2, 'ctx');
+    await vi.advanceTimersByTimeAsync(10);
+    await p2;
+
+    expect(mgr.activeWs).toBe(fresh); // the queued reconnect ran
+    expect(lastSetup(fresh).systemInstruction.parts[0].text).toContain('ACK'); // one-shot rode the next success
+  });
+
+  it('close() while reconnects are in flight/queued prevents further dials', async () => {
+    const created = [];
+    mgr.createConnection = trackDials(created);
+    mgr.activeWs = new FakeWs();
+    mgr.connectionStartTime = Date.now();
+    mgr.phase = 1;
+
+    const p1 = mgr.forceReconnect(2, 'a');
+    const p2 = mgr.forceReconnect(3, 'b');
+    await vi.advanceTimersByTimeAsync(0); // first step dequeues and dials
+    expect(created).toHaveLength(1);
+
+    mgr.close();
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.all([p1, p2]);
+    expect(created).toHaveLength(1); // queued step no-oped after close()
+  });
+});


### PR DESCRIPTION
## What

`GeminiLiveManager.forceReconnect` had no re-entrancy guard. The client WS message handler in `poc/server/index.js` is `async (raw) => …` and the ws EventEmitter doesn't await it, so two rapid client messages — an `add-context` share racing an AI phase transition, two shares back-to-back, manual `set_phase`, or `resume` — could interleave two `forceReconnect` calls. Each read a different `oldWs`, both dialed sockets, the loser's connection leaked open with handlers wired, and `reconnectionCount` double-incremented. Pre-existing on main; found by adversarial review (session handoff #185).

## Fix

- `forceReconnect` now queues `_doForceReconnect` on an in-flight promise chain (`this._reconnectQueue`). Each reconnect runs against the settled state of the previous one; the latest requested phase/contextSummary wins because it runs last; callers still await their own reconnect's outcome; a failed step is caught before it can poison the chain.
- `oneShotContext` is stored inside the queued step, so a racing share's acknowledge-directive rides the FINAL surviving connection's setup, exactly once (`sendSetup` consumes it at delivery, unchanged).
- `closed` guard in the queued step and in the open handler — a reconnect dequeued (or a socket opening) after `close()` no longer dials out. The new test suite exposed a latent NPE here: `close()` nulls `activeWs`, and a late `'open'` called `sendSetup(this.activeWs, …)` on null.

## Tests

4 new tests in `tests/unit/gemini-live.test.mjs` using the existing FakeWs + fake-timers harness:
- overlapping reconnects → exactly one surviving active connection, every predecessor closed, one armed timer set, `reconnectionCount` +1 per completed reconnect, one-shot delivered exactly once on the survivor
- three rapid reconnects → last requested phase/context wins
- socket error before open → queue not poisoned, one-shot rides the next success
- `close()` mid-queue → no further dials, no crash

Suite: **91/91** (was 87/87). Lint exit 0.

Refs #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery by serializing overlapping reconnection attempts.
  * Prevented stale or closed connections from being restored during reconnects.
  * Ensured failed reconnect attempts do not block subsequent recovery attempts.
  * Prevented additional connection attempts after the session is closed.

* **Tests**
  * Added coverage for overlapping reconnects, failed connection attempts, shutdown behavior, and context delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->