### PR TITLE
fix(gemini-live): dial timeout + failed-dial fallback; /health deploy identity

### DIFF
--- a/poc/server/gemini-live.js
+++ b/poc/server/gemini-live.js
@@ -20,6 +20,11 @@ const RECONNECT_PREPARE_MS = 13 * 60 * 1000;   // 13:00 — start preparing new 
 const RECONNECT_SETUP_MS = 13.5 * 60 * 1000;   // 13:30 — send setup to new connection
 const RECONNECT_SWAP_MS = 14 * 60 * 1000;       // 14:00 — swap to new connection
 
+// A forced-reconnect dial that emits neither 'open' nor 'error' (network
+// black-hole) would hold the serialized reconnect queue hostage until TCP
+// gives up (~75s), stalling every queued reconnect behind it. Bound it.
+const FORCE_RECONNECT_DIAL_TIMEOUT_MS = 15000;
+
 const GEMINI_WS_URL = 'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent';
 
 class GeminiLiveManager {
@@ -614,11 +619,41 @@ class GeminiLiveManager {
 
     // Create fresh connection
     await new Promise((resolve) => {
-      this.activeWs = this.createConnection();
-      this.wireHandlers(this.activeWs, false);
+      const ws = this.createConnection();
+      this.activeWs = ws;
+      this.wireHandlers(ws, false);
 
-      const ws = this.activeWs;
+      let settled = false;
+
+      // Dial failed (error or timeout): the PREVIOUS connection may still be
+      // alive — staying on it (old prompt and all) beats leaving the session
+      // pointed at a dead socket. Its connectionStartTime never changed, so
+      // re-armed swap timers keep the correct 14-minute deadline. A pending
+      // oneShotContext stays queued for the next setup that actually goes out.
+      const fallbackToOldWs = () => {
+        settled = true;
+        clearTimeout(dialTimeout);
+        // Close the dead dial while isSwapping is still true → no spurious
+        // onClose reaches the client.
+        try { ws.close(); } catch { /* never opened */ }
+        this.isSwapping = false;
+        if (oldWs && oldWs.readyState === WebSocket.OPEN && !this.closed) {
+          this.activeWs = oldWs;
+          this.scheduleReconnection();
+        }
+        resolve();
+      };
+
+      const dialTimeout = setTimeout(() => {
+        if (settled || this.closed) { resolve(); return; }
+        console.error(`[GEMINI] Force reconnect dial timed out after ${FORCE_RECONNECT_DIAL_TIMEOUT_MS}ms — releasing queue`);
+        fallbackToOldWs();
+      }, FORCE_RECONNECT_DIAL_TIMEOUT_MS);
+
       ws.on('open', () => {
+        if (settled) return; // late open after a dial timeout — superseded
+        settled = true;
+        clearTimeout(dialTimeout);
         // close() may have run while this socket was dialing — activeWs is
         // null then, and setting up / re-arming timers would resurrect a
         // dead session.
@@ -642,10 +677,10 @@ class GeminiLiveManager {
         resolve();
       });
 
-      this.activeWs.on('error', (err) => {
-        // Don't clear isSwapping — old ws close event handles it
+      ws.on('error', (err) => {
         this.onError(err);
-        resolve();
+        if (settled) return;
+        fallbackToOldWs();
       });
     });
   }

--- a/poc/server/index.js
+++ b/poc/server/index.js
@@ -198,7 +198,15 @@ app.get('/health', async (req, res) => {
   const critical = checks.gemini && checks.knowledgeBase?.ok && checks.semanticSearch?.ok;
   const status = critical ? 'healthy' : 'degraded';
 
-  res.json({ status, checks, timestamp: new Date().toISOString() });
+  res.json({
+    status,
+    checks,
+    // Deploy identity: without a SHA + uptime, every "is the new code live?"
+    // question is inference. Railway injects RAILWAY_GIT_COMMIT_SHA at build.
+    version: process.env.RAILWAY_GIT_COMMIT_SHA || 'dev',
+    uptimeSec: Math.floor(process.uptime()),
+    timestamp: new Date().toISOString()
+  });
 });
 
 // ─── REST Endpoints ───

--- a/tests/unit/gemini-live.test.mjs
+++ b/tests/unit/gemini-live.test.mjs
@@ -369,6 +369,94 @@ describe('GeminiLiveManager — forceReconnect serialization', () => {
     expect(lastSetup(fresh).systemInstruction.parts[0].text).toContain('ACK'); // one-shot rode the next success
   });
 
+  it('a failed dial falls back to the still-open previous connection instead of stranding the session', async () => {
+    const oldActive = new FakeWs();
+    mgr.activeWs = oldActive;
+    mgr.connectionStartTime = Date.now();
+    mgr.phase = 1;
+
+    const failing = new FakeWs();
+    mgr.createConnection = () => { setTimeout(() => failing.emit('error', new Error('dial refused')), 1); return failing; };
+
+    const p = mgr.forceReconnect(2, 'ctx');
+    await vi.advanceTimersByTimeAsync(10);
+    await p;
+
+    expect(mgr.activeWs).toBe(oldActive);        // restored — session keeps talking on the old line
+    expect(oldActive.readyState).toBe(1);        // old connection untouched
+    expect(failing.readyState).toBe(3);          // dead dial closed, not leaked
+    expect(mgr.isSwapping).toBe(false);          // future closes reach onClose
+    expect(mgr.reconnectTimers).toHaveLength(3); // swap timers re-armed for the old line
+  });
+
+  it('a dial that never opens NOR errors times out, releases the queue, and recovers', async () => {
+    const oldActive = new FakeWs();
+    mgr.activeWs = oldActive;
+    mgr.connectionStartTime = Date.now();
+    mgr.phase = 1;
+
+    const hung = new FakeWs(); // network black-hole: no open, no error
+    const fresh = new FakeWs();
+    let dials = 0;
+    mgr.createConnection = () => {
+      dials++;
+      if (dials === 1) return hung;
+      setTimeout(() => fresh.emit('open'), 1);
+      return fresh;
+    };
+
+    const p1 = mgr.forceReconnect(2, 'ctx-hung');
+    const p2 = mgr.forceReconnect(3, 'ctx-next'); // queued behind the hung dial
+
+    await vi.advanceTimersByTimeAsync(14000);
+    expect(dials).toBe(1);          // still head-of-line blocked
+    expect(mgr.activeWs).toBe(hung);
+
+    await vi.advanceTimersByTimeAsync(2000); // 15s dial timeout fires
+    await Promise.all([p1, p2]);
+
+    expect(hung.readyState).toBe(3);   // hung socket closed
+    expect(dials).toBe(2);             // queue released — second reconnect ran
+    expect(mgr.activeWs).toBe(fresh);
+    expect(mgr.phase).toBe(3);
+    expect(oldActive.readyState).toBe(3); // superseded by the successful reconnect
+  });
+
+  it('stress: 10 randomly interleaved reconnects with intermittent failures preserve every invariant', async () => {
+    const initial = new FakeWs();
+    mgr.activeWs = initial;
+    mgr.connectionStartTime = Date.now();
+    mgr.phase = 0;
+
+    const created = [];
+    let dials = 0;
+    mgr.createConnection = () => {
+      const f = new FakeWs();
+      created.push(f);
+      const n = ++dials;
+      if (n % 4 === 0) setTimeout(() => f.emit('error', new Error('boom')), n % 7); // every 4th dial fails
+      else setTimeout(() => f.emit('open'), n % 7);
+      return f;
+    };
+
+    const ps = [];
+    for (let i = 1; i <= 10; i++) {
+      ps.push(mgr.forceReconnect(i % 8, `ctx-${i}`, i % 3 === 0 ? { oneShotContext: `SHOT-${i}` } : {}));
+    }
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.all(ps);
+
+    expect(created).toHaveLength(10); // serialized: every request dialed exactly once
+    // THE invariant: exactly one socket open across everything ever created
+    const open = [initial, ...created].filter((w) => w.readyState === 1);
+    expect(open).toHaveLength(1);
+    expect(open[0]).toBe(mgr.activeWs);
+    expect(mgr.phase).toBe(2);                   // last request (10 % 8) won
+    expect(mgr.contextSummary).toBe('ctx-10');
+    expect(mgr.reconnectTimers).toHaveLength(3); // one armed timer set
+    expect(mgr.oneShotContext).toBeNull();       // every one-shot consumed
+  });
+
   it('close() while reconnects are in flight/queued prevents further dials', async () => {
     const created = [];
     mgr.createConnection = trackDials(created);


### PR DESCRIPTION
Adversarial squeeze pass on #187 (refs #185). Three finds, all fixed:

1. **Head-of-line blocking introduced by the serialization fix itself.** A dial that emits neither `open` nor `error` (network black-hole) held the reconnect queue hostage for ~75s of TCP timeout — stalling phase transitions, shares, and resume behind it. Now bounded by a 15s dial timeout that closes the hung socket and releases the queue.

2. **Failed dial stranded the session on a dead socket** while the previous connection might still be alive. Now: `activeWs` is restored to the still-open old connection, `isSwapping` cleared, and swap timers re-armed against its original `connectionStartTime` (correct 14-min deadline). A failed reconnect degrades to 'keep talking on the old line' instead of dead air. The dead dial is closed while `isSwapping` is still true, so no spurious `onClose` reaches the client.

3. **`/health` gains `version` (Railway's `RAILWAY_GIT_COMMIT_SHA`) + `uptimeSec`** — deploy verification becomes direct observation instead of inference. This PR's own deploy is the first directly-proven one.

Tests: fallback restore · dial-timeout queue release · 10-way interleaved stress with intermittent failures (invariant: exactly one open socket across everything ever created). Suite **94/94**, lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)